### PR TITLE
Add ability to specify Key Provider for certificate generation

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -125,7 +125,8 @@ public class CertificateManager
                     .ToList(),
                 values.KeyLength,
                 values.LocalCertStore,
-                new()
+                new(),
+                values.KeyProvider
             );
             string csr = certRequest.RawData[EncodingType.XCN_CRYPT_STRING_BASE64REQUESTHEADER];
             _logger.LogInformation($"Renewing certificate");
@@ -159,7 +160,7 @@ public class CertificateManager
         }
         try
         {
-            if (values.RDPCert && values.LocalCertStore == false)
+            if (values is { RDPCert: true, LocalCertStore: false })
             {
                 throw new ArgumentException(
                     "If certificate will be used for RDP it must be stored in the local store"
@@ -204,7 +205,9 @@ public class CertificateManager
                 ezcaClient,
                 false,
                 ekus,
-                values.KeyLength
+                values.KeyLength,
+                "",
+                values.KeyProvider
             );
             if (values.RDPCert)
             {
@@ -281,7 +284,8 @@ public class CertificateManager
                 true,
                 values.EKUs,
                 values.KeyLength,
-                values.DCGUID
+                values.DCGUID,
+                values.KeyProvider
             );
         }
         catch (Exception ex)
@@ -431,7 +435,8 @@ public class CertificateManager
         bool dcCertificate,
         List<string> ekus,
         int keyLength,
-        string dcGUID = ""
+        string dcGUID = "",
+        string keyProvider = "Microsoft Enhanced Cryptographic Provider v1.0"
     )
     {
         if (_logger == null)
@@ -462,7 +467,8 @@ public class CertificateManager
             subjectAltNames,
             keyLength,
             localStore,
-            ekus
+            ekus,
+            keyProvider
         );
         string csr = certRequest.RawData[EncodingType.XCN_CRYPT_STRING_BASE64REQUESTHEADER];
         X509Certificate2? windowsCert;

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/CreateDCCertificate.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/CreateDCCertificate.cs
@@ -79,4 +79,13 @@ public class CreateDCCertificate
     
     [Option('k', "KeyLength",  HelpText = "Certificate Key Length", Default = 4096)]
     public int KeyLength { get; set; } = 4096;
+    [Option(
+        'p',
+        "KeyProvider",
+        Required = false,
+        Default = "Microsoft Enhanced Cryptographic Provider v1.0",
+        HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
+            
+    )]
+    public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
@@ -77,5 +77,14 @@ namespace DotNetCertAuthSample.Models
         
         [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
         public int KeyLength { get; set; } = 4096;
+        [Option(
+            'p',
+            "KeyProvider",
+            Required = false,
+            Default = "Microsoft Enhanced Cryptographic Provider v1.0",
+            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
+            
+        )]
+        public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
     }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
@@ -65,5 +65,14 @@ namespace DotNetCertAuthSample.Models
         public string issuer { get; set; } = "";
         [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
         public int KeyLength { get; set; } = 4096;
+        [Option(
+            'p',
+            "KeyProvider",
+            Required = false,
+            Default = "Microsoft Enhanced Cryptographic Provider v1.0",
+            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
+            
+        )]
+        public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
     }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "DotNetCertAuthSample": {
       "commandName": "Project",
-      "commandLineArgs": " renew -s \"CN=server3.contoso.com\" -i \"SCEP Any Root  Extras\" --LocalStore --EZCAInstance https://localhost:5001/ -k 2048" //https://ezcaeastuswin-testslot.azurewebsites.net/ "
-//     "commandLineArgs": "createDC  -s \"CN=server3.contoso.com-tpm\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  -p \"Microsoft Platform Crypto Provider\" --EZCAInstance https://localhost:5001/"
+//      "commandLineArgs": " renew -s \"CN=server3.contoso.com\" -i \"SCEP Any Root  Extras\" --LocalStore --EZCAInstance https://localhost:5001/ -k 2048" //https://ezcaeastuswin-testslot.azurewebsites.net/ "
+     "commandLineArgs": "createDC  -s \"CN=server3.contoso.com-tpm\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  -p \"Microsoft Platform Crypto Provider\" --EZCAInstance https://localhost:5001/"
     }
   }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "DotNetCertAuthSample": {
       "commandName": "Project",
-//      "commandLineArgs": " renew -s \"CN=server3.contoso.com\" -i \"SCEP Any Root  Extras\" --LocalStore --EZCAInstance https://localhost:5001/ -k 2048" //https://ezcaeastuswin-testslot.azurewebsites.net/ "
-     "commandLineArgs": "createDC  -s \"CN=server3.contoso.com OU=Domain Controllers, DC=contoso DC=com\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  --EZCAInstance https://localhost:5001/"
+      "commandLineArgs": " renew -s \"CN=server3.contoso.com\" -i \"SCEP Any Root  Extras\" --LocalStore --EZCAInstance https://localhost:5001/ -k 2048" //https://ezcaeastuswin-testslot.azurewebsites.net/ "
+//     "commandLineArgs": "createDC  -s \"CN=server3.contoso.com-tpm\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  -p \"Microsoft Platform Crypto Provider\" --EZCAInstance https://localhost:5001/"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Sample call:
 
 If your domain is already registered in EZCA (either by calling the register function mentioned above, or by [registering a domain in the EZCA portal](https://docs.keytos.io/azure-pki/registering-a-domain/registering_new_domain/)), you should use the ```create``` option. This option will use a [DefaultAzureCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) to authenticate to EZCA and request a certificate. Please ensure that the identity being used to authenticate is registered as a requester for this domain. **Note: unlike with register this can be run by machine identities**
 ```
--r, --RDP             (Default: false) whether this certificate should be added as the computer's RDP certificate
+  -r, --RDP             (Default: false) whether this certificate should be added as the computer's RDP certificate
 
-  -d, --Domain          Required. Domain for the certificate you want to create
+  -d, --Domain          Domain for the certificate you want to create
 
   --AppInsights         Azure Application Insights connection string to send logs to
 
@@ -34,15 +34,24 @@ If your domain is already registered in EZCA (either by calling the register fun
 
   --caid                Required. CA ID of the CA you want to request the certificate from
 
-  --LocalStore          (Default: false) If the certificate should be stored in the computers Local Store. If false certificate will be stored in the user store
+  --LocalStore          (Default: false) If the certificate should be stored in the computers Local Store. If false
+                        certificate will be stored in the user store
 
   -v, --Validity        Required. Certificate validity in days
 
-  --AzTenantID          Optional If you want to authenticate with an Azure application you must pass you Azure TenantID, the Application ID and the Application Secret
+  --AzTenantID          Optional If you want to authenticate with an Azure application you must pass you Azure TenantID,
+                        the Application ID and the Application Secret
 
-  --AzAppID             Optional If you want to authenticate with an Azure application you must pass you Azure TenantID, the Application ID and the Application Secret
+  --AzAppID             Optional If you want to authenticate with an Azure application you must pass you Azure TenantID,
+                        the Application ID and the Application Secret
 
-  --AzAppSecret         Optional If you want to authenticate with an Azure application you must pass you Azure TenantID, the Application ID and the Application Secret
+  --AzAppSecret         Optional If you want to authenticate with an Azure application you must pass you Azure TenantID,
+                        the Application ID and the Application Secret
+
+  -k, --KeyLength       (Default: 4096) Certificate Key Length
+
+  -p, --KeyProvider     (Default: Microsoft Enhanced Cryptographic Provider v1.0) Certificate Key Provider (Default:
+                        Microsoft Enhanced Cryptographic Provider v1.0)
 
   --help                Display this help screen.
 
@@ -56,10 +65,10 @@ Once again if you want to use this certificate for RDP we must add ```--LocalSto
 If you are trying to go passwordless with [hello for business hybrid key trust deployment](https://learn.microsoft.com/en-us/windows/security/identity-protection/hello-for-business/hello-hybrid-key-trust), you can use this application to [request the domain controller certificate](https://docs.keytos.io/azure-pki/intune-certificate-authority/domain-controller-certificates-for-windows-hello-hybrid/#using-the-application).
 The following options are available for this command:
 ```
-   -d, --DNS             Required. DNS Entry for this Domain Controller
+ -d, --DNS             DNS Entry for this Domain Controller
 
-  -s, --SubjectName     Required. Subject Name for this certificate for example: CN=server1.contoso.com OU=Domain
-                        Controllers DC=contoso DC=com
+  -s, --SubjectName     Subject Name for this certificate for example: CN=server1.contoso.com OU=Domain Controllers
+                        DC=contoso DC=com
 
   --caid                Required. CA ID of the CA you want to request the certificate from
 
@@ -69,8 +78,8 @@ The following options are available for this command:
   -v, --Validity        Required. Certificate validity in days
 
   -g, --DCGUID          Domain Controller GUID. This is only required if SMTP replication is used in your domain. Learn
-                        more:
-                        https://learn.microsoft.com/en-US/troubleshoot/windows-server/windows-security/requirements-doma                        in-controller#how-to-determine-the-domain-controller-guid
+                        more: https://learn.microsoft.com/en-US/troubleshoot/windows-server/windows-security/requirements-doma
+                        in-controller#how-to-determine-the-domain-controller-guid
 
   --AppInsights         Azure Application Insights connection string to send logs to
 
@@ -80,6 +89,15 @@ The following options are available for this command:
                         requested for the certificate
 
   --AzureCLI            (Default: false) Use Azure CLI as authentication method
+
+  -k, --KeyLength       (Default: 4096) Certificate Key Length
+
+  -p, --KeyProvider     (Default: Microsoft Enhanced Cryptographic Provider v1.0) Certificate Key Provider (Default:
+                        Microsoft Enhanced Cryptographic Provider v1.0)
+
+  --help                Display this help screen.
+
+  --version             Display version information.
 ```
 sample command:
 ``` 
@@ -89,15 +107,25 @@ sample command:
 ## Renew an existing certificate
 Once a certificate has been created and is in your Windows store, we recommend setting a scheduled task running this binary with the renew function to automatically renew your certificate. This uses the existing certificate to authenticate so no need for an AAD identity. For this one the only required option is the ```-d``` with the subject name of the certificate, the console application will use that information to get the certificate from the store you specify and renew it in EZCA.
 ```
- -r, --RDP             (Default: false) whether this certificate should be added as the computer's RDP certificate
+  -r, --RDP             (Default: false) whether this certificate should be added as the computer's RDP certificate
 
-  -s, --SubjectName          Required. Domain for the certificate you want to create
+  -s, --SubjectName     Required. SubjectName for the certificate you want to renew
 
   --AppInsights         Azure Application Insights connection string to send logs to
 
   -e, --EZCAInstance    (Default: https://portal.ezca.io/) EZCA instance url
 
-  --LocalStore          (Default: false) If the certificate should be stored in the computers Local Store. If false certificate will be stored in the user store
+  --LocalStore          (Default: false) If the certificate should be stored in the computers Local Store. If false
+                        certificate will be stored in the user store
+
+  -t, --Template        (Default: ) Certificate Template Name
+
+  -i, --Issuer          (Default: ) Certificate Issuer Name
+
+  -k, --KeyLength       (Default: 4096) Certificate Key Length
+
+  -p, --KeyProvider     (Default: Microsoft Enhanced Cryptographic Provider v1.0) Certificate Key Provider (Default:
+                        Microsoft Enhanced Cryptographic Provider v1.0)
 
   --help                Display this help screen.
 


### PR DESCRIPTION
This pull request adds the ability to specify a Key Provider when generating certificates. The default Key Provider is "Microsoft Enhanced Cryptographic Provider v1.0". This feature allows users to choose a different Key Provider if needed.