### PR TITLE
Fix for multiple certificates for store

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
@@ -43,7 +43,8 @@ namespace DotNetCertAuthSample.Services
                         .Find(X509FindType.FindByIssuerName, issuerName, true)
                         .FirstOrDefault();
                 }
-                cert ??= certs.OrderByDescending(i => i.NotAfter).First();
+                cert ??= certs.OrderByDescending(x => x.NotAfter).FirstOrDefault(i => 
+                    i.SubjectName.Name == $"CN={subjectName}") ?? certs.OrderByDescending(x => x.NotAfter).First();
             }
             else
             {


### PR DESCRIPTION
This pull request includes a fix for an issue where multiple certificates were being returned for a store. The fix ensures that only the certificate with the latest expiration date is selected, and if a specific subject name is provided, it will prioritize that certificate.