### PR TITLE
++ Add SCEP Issuance

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -18,22 +18,22 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Management.Infrastructure;
 using Microsoft.Management.Infrastructure.Options;
 using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.X509;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Pkcs;
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.X509.Extension;
 using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.Sec;
 using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Cms;
+using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Digests;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Operators;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Prng;
 using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
 using AttributeTable = Org.BouncyCastle.Asn1.Cms.AttributeTable;
 using ContentInfo = System.Security.Cryptography.Pkcs.ContentInfo;
 using SignerInfo = System.Security.Cryptography.Pkcs.SignerInfo;
@@ -82,7 +82,7 @@ public class CertificateManager
         _createDCCertArgModel = values;
         return 0;
     }
-    
+
     public int InitializeManager(SCEPArgModel values)
     {
         _logger = CreateLogger(values.AppInsightsKey);
@@ -142,7 +142,7 @@ public class CertificateManager
             {
                 throw new ArgumentNullException(nameof(values.Domain));
             }
-            if(values.KeyLength != 2048 && values.KeyLength != 4096)
+            if (values.KeyLength != 2048 && values.KeyLength != 4096)
             {
                 throw new ArgumentException("Key length must be 2048 or 4096");
             }
@@ -213,7 +213,7 @@ public class CertificateManager
                     throw new ArgumentNullException(nameof(values.Domain));
                 }
             }
-            if(values.KeyLength != 2048 && values.KeyLength != 4096)
+            if (values.KeyLength != 2048 && values.KeyLength != 4096)
             {
                 throw new ArgumentException("Key length must be 2048 or 4096");
             }
@@ -303,7 +303,7 @@ public class CertificateManager
                 values.url,
                 CreateTokenCredential(values.AzureCLI)
             );
-            if(values.KeyLength != 2048 && values.KeyLength != 4096)
+            if (values.KeyLength != 2048 && values.KeyLength != 4096)
             {
                 throw new ArgumentException("Key length must be 2048 or 4096");
             }
@@ -331,7 +331,7 @@ public class CertificateManager
         }
         return 0;
     }
-    
+
     private async Task<int> CreateSCEPCertificate(SCEPArgModel values)
     {
         if (_logger == null)
@@ -361,13 +361,17 @@ public class CertificateManager
             }
             if (values.EKUs == null || values.EKUs.Any() == false)
             {
-                values.EKUs = [EZCAConstants.ClientAuthenticationEKU, EZCAConstants.ServerAuthenticationEKU];
+                values.EKUs =
+                [
+                    EZCAConstants.ClientAuthenticationEKU,
+                    EZCAConstants.ServerAuthenticationEKU
+                ];
             }
-            if(values.KeyLength != 2048 && values.KeyLength != 4096)
+            if (values.KeyLength != 2048 && values.KeyLength != 4096)
             {
                 throw new ArgumentException("Key length must be 2048 or 4096");
             }
-            if(string.IsNullOrWhiteSpace(values.url))
+            if (string.IsNullOrWhiteSpace(values.url))
             {
                 throw new ArgumentNullException(nameof(values.url));
             }
@@ -395,9 +399,12 @@ public class CertificateManager
         return 0;
     }
 
-    private async Task<int> RequestSCEPCertificateAsync(X509Certificate2 caCertificate,
+    private async Task<int> RequestSCEPCertificateAsync(
+        X509Certificate2 caCertificate,
         AsymmetricCipherKeyPair rsaKeyPair,
-        Pkcs10CertificationRequest request, SCEPArgModel values)
+        Pkcs10CertificationRequest request,
+        SCEPArgModel values
+    )
     {
         try
         {
@@ -406,37 +413,59 @@ public class CertificateManager
             envelopedDataGenerator.AddKeyTransRecipient(bouncyCastleCACert);
             CmsProcessable req = new CmsProcessableByteArray(request.GetDerEncoded());
             CmsEnvelopedData encryptedEnvelope = envelopedDataGenerator.Generate(
-                req, CmsEnvelopedGenerator.Aes256Cbc);
+                req,
+                CmsEnvelopedGenerator.Aes256Cbc
+            );
             byte[] encryptedBytes = encryptedEnvelope.GetEncoded();
-            //create Signing Key    
+            //create Signing Key
             AsymmetricCipherKeyPair signingKeyPair = CreateKeyPair($"RSA {values.KeyLength}");
             X509Certificate2 cert = GenerateSelfSignedCertificate(signingKeyPair, "TempCert");
-            CmsSigner signer = new(
-                cert
+            CmsSigner signer = new(cert);
+            var messageType = new AsnEncodedData(
+                "2.16.840.1.113733.1.9.2",
+                DerEncoding.EncodePrintableString("19")
             );
-            var messageType = new AsnEncodedData("2.16.840.1.113733.1.9.2", DerEncoding.EncodePrintableString("19"));
             signer.SignedAttributes.Add(messageType);
-            var transactionID = new Pkcs9AttributeObject("2.16.840.1.113733.1.9.7", DerEncoding.EncodePrintableString( 
-                Convert.ToBase64String(SHA512.HashData(cert.GetPublicKey()))));
+            var transactionID = new Pkcs9AttributeObject(
+                "2.16.840.1.113733.1.9.7",
+                DerEncoding.EncodePrintableString(
+                    Convert.ToBase64String(SHA512.HashData(cert.GetPublicKey()))
+                )
+            );
             signer.SignedAttributes.Add(transactionID);
             SecureRandom random = new SecureRandom();
             byte[] nonceBytes = new byte[16]; // Typically a 16-byte nonce
             random.NextBytes(nonceBytes);
-            var nonce = new Pkcs9AttributeObject("2.16.840.1.113733.1.9.5", DerEncoding.EncodeOctet(nonceBytes));
+            var nonce = new Pkcs9AttributeObject(
+                "2.16.840.1.113733.1.9.5",
+                DerEncoding.EncodeOctet(nonceBytes)
+            );
             signer.SignedAttributes.Add(nonce);
-            ContentInfo signedContent = new (encryptedBytes);
-            SignedCms signedMessage = new (signedContent);
+            ContentInfo signedContent = new(encryptedBytes);
+            SignedCms signedMessage = new(signedContent);
             signedMessage.ComputeSignature(signer);
             byte[] signedBytes = signedMessage.Encode();
             ByteArrayContent content = new ByteArrayContent(signedBytes);
-            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-pki-message");
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+                "application/x-pki-message"
+            );
             HttpResponseMessage response = await _httpClient.PostAsync(values.url, content);
             if (!response.IsSuccessStatusCode)
             {
-                throw new Exception($"Failed to request SCEP certificate: {response.StatusCode} " + await response.Content.ReadAsStringAsync());
+                throw new Exception(
+                    $"Failed to request SCEP certificate: {response.StatusCode} "
+                        + await response.Content.ReadAsStringAsync()
+                );
             }
             byte[] responseBytes = await response.Content.ReadAsByteArrayAsync();
-            return DecodeAndInstallSCEPCertificate(responseBytes, rsaKeyPair, caCertificate, nonceBytes, cert, values.LocalCertStore);
+            return DecodeAndInstallSCEPCertificate(
+                responseBytes,
+                rsaKeyPair,
+                caCertificate,
+                nonceBytes,
+                cert,
+                values.LocalCertStore
+            );
         }
         catch (Exception ex)
         {
@@ -446,21 +475,25 @@ public class CertificateManager
         }
     }
 
-    private int DecodeAndInstallSCEPCertificate(byte[] responseBytes, AsymmetricCipherKeyPair rsaKeyPair, 
-        X509Certificate2 caCertificate, byte[] nonce, X509Certificate2 signingCert, bool localStore)
+    private int DecodeAndInstallSCEPCertificate(
+        byte[] responseBytes,
+        AsymmetricCipherKeyPair rsaKeyPair,
+        X509Certificate2 caCertificate,
+        byte[] nonce,
+        X509Certificate2 signingCert,
+        bool localStore
+    )
     {
         var signedResponse = new SignedCms();
         signedResponse.Decode(responseBytes);
-        X509Certificate2Collection caCerts =
-        [
-            caCertificate
-        ];
+        X509Certificate2Collection caCerts = [caCertificate];
         signedResponse.CheckSignature(caCerts, true);
         var attributes = signedResponse
-            .SignerInfos
-            .Cast<SignerInfo>()
+            .SignerInfos.Cast<SignerInfo>()
             .SelectMany(si => si.SignedAttributes.Cast<CryptographicAttributeObject>());
-        var recipientNonce = attributes.FirstOrDefault(a => a.Oid.Value =="2.16.840.1.113733.1.9.6");
+        var recipientNonce = attributes.FirstOrDefault(a =>
+            a.Oid.Value == "2.16.840.1.113733.1.9.6"
+        );
         if (recipientNonce == null)
         {
             throw new Exception("Recipient nonce not found in response");
@@ -481,8 +514,12 @@ public class CertificateManager
         WindowsCertStoreService.InstallFullCertificate(cert, localStore);
         return 0;
     }
-    
-    private static X509Certificate2 GenerateSelfSignedCertificate(AsymmetricCipherKeyPair keyPair, string subjectName, int validDays =2)
+
+    private static X509Certificate2 GenerateSelfSignedCertificate(
+        AsymmetricCipherKeyPair keyPair,
+        string subjectName,
+        int validDays = 2
+    )
     {
         // Create the certificate generator
         X509V3CertificateGenerator certGen = new X509V3CertificateGenerator();
@@ -506,31 +543,52 @@ public class CertificateManager
         certGen.SetPublicKey(keyPair.Public);
 
         // Optionally add extensions (like Basic Constraints, Key Usage, etc.)
-        certGen.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(true));  // Cert is allowed to act as a CA
+        certGen.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(true)); // Cert is allowed to act as a CA
 
         // Sign the certificate with the private key
-        ISignatureFactory signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private);
+        ISignatureFactory signatureFactory = new Asn1SignatureFactory(
+            "SHA256WITHRSA",
+            keyPair.Private
+        );
         X509Certificate bouncyCastleCert = certGen.Generate(signatureFactory);
         X509Certificate2 cert = new X509Certificate2(bouncyCastleCert.GetEncoded());
         RSA rsaPrivateKey = DotNetUtilities.ToRSA((RsaPrivateCrtKeyParameters)keyPair.Private);
         cert = cert.CopyWithPrivateKey(rsaPrivateKey);
         return cert;
     }
-    
-    private Pkcs10CertificationRequest CreateCSRForScep(SCEPArgModel values,
-        string challengePassword, AsymmetricCipherKeyPair rsaKeyPair)
+
+    private Pkcs10CertificationRequest CreateCSRForScep(
+        SCEPArgModel values,
+        string challengePassword,
+        AsymmetricCipherKeyPair rsaKeyPair
+    )
     {
-        AttributePkcs scepPassword = new AttributePkcs(PkcsObjectIdentifiers.Pkcs9AtChallengePassword, new DerSet(new DerPrintableString(challengePassword)));
+        AttributePkcs scepPassword = new AttributePkcs(
+            PkcsObjectIdentifiers.Pkcs9AtChallengePassword,
+            new DerSet(new DerPrintableString(challengePassword))
+        );
         X509ExtensionsGenerator extensions = new X509ExtensionsGenerator();
         if (!string.IsNullOrWhiteSpace(values.SubjectAltNames))
         {
             GeneralNames subjectAlternateNames = new GeneralNames(
-                values.SubjectAltNames.Split(',').Select(dnsName => new GeneralName(GeneralName.DnsName, dnsName)).ToArray()
+                values
+                    .SubjectAltNames.Split(',')
+                    .Select(dnsName => new GeneralName(GeneralName.DnsName, dnsName))
+                    .ToArray()
             );
-            extensions.AddExtension(X509Extensions.SubjectAlternativeName, false, subjectAlternateNames);
+            extensions.AddExtension(
+                X509Extensions.SubjectAlternativeName,
+                false,
+                subjectAlternateNames
+            );
         }
-        AttributePkcs extensionRequest = new AttributePkcs(PkcsObjectIdentifiers.Pkcs9AtExtensionRequest, new DerSet(extensions.Generate()));
-        Asn1Encodable ekus = new ExtendedKeyUsage(values.EKUs.Select(oid => new DerObjectIdentifier(oid)).ToArray());
+        AttributePkcs extensionRequest = new AttributePkcs(
+            PkcsObjectIdentifiers.Pkcs9AtExtensionRequest,
+            new DerSet(extensions.Generate())
+        );
+        Asn1Encodable ekus = new ExtendedKeyUsage(
+            values.EKUs.Select(oid => new DerObjectIdentifier(oid)).ToArray()
+        );
         extensions.AddExtension(X509Extensions.ExtendedKeyUsage, false, ekus);
         //key usage
         extensions.AddExtension(
@@ -539,9 +597,9 @@ public class CertificateManager
             (
                 new KeyUsage(
                     KeyUsage.KeyEncipherment
-                    | KeyUsage.DigitalSignature
-                    | KeyUsage.KeyCertSign
-                    | KeyUsage.CrlSign
+                        | KeyUsage.DigitalSignature
+                        | KeyUsage.KeyCertSign
+                        | KeyUsage.CrlSign
                 )
             ).ToAsn1Object()
         );
@@ -554,7 +612,7 @@ public class CertificateManager
         );
         return request;
     }
-    
+
     private static AsymmetricCipherKeyPair CreateKeyPair(string keyAlgo)
     {
         var randomGenerator = new CryptoApiRandomGenerator();
@@ -588,23 +646,30 @@ public class CertificateManager
         }
         throw new NotImplementedException($"Algorithm {keyAlgo} not supported");
     }
-    
+
     private async Task<X509Certificate2> GetScepCA(string scepURL)
     {
-        HttpResponseMessage caResponse  = await _httpClient.GetAsync(string.Concat(scepURL, "?operation=GetCACert&message=ca"));
+        HttpResponseMessage caResponse = await _httpClient.GetAsync(
+            string.Concat(scepURL, "?operation=GetCACert&message=ca")
+        );
         if (caResponse.IsSuccessStatusCode)
         {
             byte[] caCertData = await caResponse.Content.ReadAsByteArrayAsync();
-            X509Certificate2 caCert =  new (caCertData);
+            X509Certificate2 caCert = new(caCertData);
             // Validate the chain to ensure we trust the CA
             X509Chain chain = new();
             if (chain.Build(caCert))
             {
                 return caCert;
             }
-            throw new Exception("Error building chain for SCEP CA certificate: " + chain.ChainStatus[0].StatusInformation);
+            throw new Exception(
+                "Error building chain for SCEP CA certificate: "
+                    + chain.ChainStatus[0].StatusInformation
+            );
         }
-        throw new Exception("Error getting SCEP CA certificate: " + await caResponse.Content.ReadAsStringAsync());
+        throw new Exception(
+            "Error getting SCEP CA certificate: " + await caResponse.Content.ReadAsStringAsync()
+        );
     }
 
     private string GetComputerSubjectName()
@@ -760,7 +825,7 @@ public class CertificateManager
                 "Error certificate validity has to be greater than 0"
             );
         }
-        if(keyLength != 2048 && keyLength != 4096)
+        if (keyLength != 2048 && keyLength != 4096)
         {
             throw new ArgumentException("Key length must be 2048 or 4096");
         }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Core;
 using Azure.Identity;
@@ -18,8 +19,25 @@ using Microsoft.Management.Infrastructure;
 using Microsoft.Management.Infrastructure.Options;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Pkcs;
 using Org.BouncyCastle.X509;
 using Org.BouncyCastle.X509.Extension;
+using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Cms;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using AttributeTable = Org.BouncyCastle.Asn1.Cms.AttributeTable;
+using ContentInfo = System.Security.Cryptography.Pkcs.ContentInfo;
+using SignerInfo = System.Security.Cryptography.Pkcs.SignerInfo;
+using X509Certificate = Org.BouncyCastle.X509.X509Certificate;
 
 namespace DotNetCertAuthSample.Managers;
 
@@ -30,6 +48,8 @@ public class CertificateManager
     private GenerateArgModel? _generateArgModel;
     private RegisterArgModel? _registerArgModel;
     private CreateDCCertificate? _createDCCertArgModel;
+    private SCEPArgModel? _scepArgModel;
+    private HttpClient _httpClient = new();
 
     public int InitializeManager(RenewArgModel values)
     {
@@ -62,6 +82,17 @@ public class CertificateManager
         _createDCCertArgModel = values;
         return 0;
     }
+    
+    public int InitializeManager(SCEPArgModel values)
+    {
+        _logger = CreateLogger(values.AppInsightsKey);
+        if (!string.IsNullOrWhiteSpace(values.EKUsInputs))
+        {
+            values.EKUs = values.EKUsInputs.Split(',').ToList();
+        }
+        _scepArgModel = values;
+        return 0;
+    }
 
     public int ProcessError(IEnumerable<Error> errs)
     {
@@ -85,6 +116,10 @@ public class CertificateManager
         if (_createDCCertArgModel != null)
         {
             return await CreateDCCertAsync(_createDCCertArgModel);
+        }
+        if (_scepArgModel != null)
+        {
+            return await CreateSCEPCertificate(_scepArgModel);
         }
         return -1;
     }
@@ -295,6 +330,281 @@ public class CertificateManager
             return 1;
         }
         return 0;
+    }
+    
+    private async Task<int> CreateSCEPCertificate(SCEPArgModel values)
+    {
+        if (_logger == null)
+        {
+            throw new ArgumentNullException(nameof(_logger));
+        }
+        try
+        {
+            if (string.IsNullOrWhiteSpace(values.SubjectAltNames))
+            {
+                values.SubjectAltNames = GetFQDN();
+                if (string.IsNullOrWhiteSpace(values.SubjectAltNames))
+                {
+                    throw new ArgumentNullException(nameof(values.SubjectAltNames));
+                }
+            }
+            if (string.IsNullOrWhiteSpace(values.SubjectName))
+            {
+                values.SubjectName = GetComputerSubjectName();
+                if (string.IsNullOrWhiteSpace(values.SubjectName))
+                {
+                    throw new ArgumentNullException(
+                        nameof(values.SubjectName),
+                        "Please enter a valid Subject Name"
+                    );
+                }
+            }
+            if (values.EKUs == null || values.EKUs.Any() == false)
+            {
+                values.EKUs = [EZCAConstants.ClientAuthenticationEKU, EZCAConstants.ServerAuthenticationEKU];
+            }
+            if(values.KeyLength != 2048 && values.KeyLength != 4096)
+            {
+                throw new ArgumentException("Key length must be 2048 or 4096");
+            }
+            if(string.IsNullOrWhiteSpace(values.url))
+            {
+                throw new ArgumentNullException(nameof(values.url));
+            }
+            //TIP: you can hardcode the password here or use a secure secret manager to avoid having the password in the Script
+            // values.SCEPPassword = "YourPassword";
+            if (string.IsNullOrWhiteSpace(values.SCEPPassword))
+            {
+                throw new ArgumentNullException(nameof(values.SCEPPassword));
+            }
+            X509Certificate2 caCert = await GetScepCA(values.url);
+            AsymmetricCipherKeyPair rsaKeyPair = CreateKeyPair($"RSA {values.KeyLength}");
+            Pkcs10CertificationRequest request = CreateCSRForScep(
+                values,
+                values.SCEPPassword,
+                rsaKeyPair
+            );
+            return await RequestSCEPCertificateAsync(caCert, rsaKeyPair, request, values);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating SCEP certificate");
+            Console.WriteLine("Error creating certificate: " + ex.Message);
+            return 1;
+        }
+        return 0;
+    }
+
+    private async Task<int> RequestSCEPCertificateAsync(X509Certificate2 caCertificate,
+        AsymmetricCipherKeyPair rsaKeyPair,
+        Pkcs10CertificationRequest request, SCEPArgModel values)
+    {
+        try
+        {
+            X509Certificate bouncyCastleCACert = DotNetUtilities.FromX509Certificate(caCertificate);
+            CmsEnvelopedDataGenerator envelopedDataGenerator = new();
+            envelopedDataGenerator.AddKeyTransRecipient(bouncyCastleCACert);
+            CmsProcessable req = new CmsProcessableByteArray(request.GetDerEncoded());
+            CmsEnvelopedData encryptedEnvelope = envelopedDataGenerator.Generate(
+                req, CmsEnvelopedGenerator.Aes256Cbc);
+            byte[] encryptedBytes = encryptedEnvelope.GetEncoded();
+            //create Signing Key    
+            AsymmetricCipherKeyPair signingKeyPair = CreateKeyPair($"RSA {values.KeyLength}");
+            X509Certificate2 cert = GenerateSelfSignedCertificate(signingKeyPair, "TempCert");
+            CmsSigner signer = new(
+                cert
+            );
+            var messageType = new AsnEncodedData("2.16.840.1.113733.1.9.2", DerEncoding.EncodePrintableString("19"));
+            signer.SignedAttributes.Add(messageType);
+            var transactionID = new Pkcs9AttributeObject("2.16.840.1.113733.1.9.7", DerEncoding.EncodePrintableString( 
+                Convert.ToBase64String(SHA512.HashData(cert.GetPublicKey()))));
+            signer.SignedAttributes.Add(transactionID);
+            SecureRandom random = new SecureRandom();
+            byte[] nonceBytes = new byte[16]; // Typically a 16-byte nonce
+            random.NextBytes(nonceBytes);
+            var nonce = new Pkcs9AttributeObject("2.16.840.1.113733.1.9.5", DerEncoding.EncodeOctet(nonceBytes));
+            signer.SignedAttributes.Add(nonce);
+            ContentInfo signedContent = new (encryptedBytes);
+            SignedCms signedMessage = new (signedContent);
+            signedMessage.ComputeSignature(signer);
+            byte[] signedBytes = signedMessage.Encode();
+            ByteArrayContent content = new ByteArrayContent(signedBytes);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/x-pki-message");
+            HttpResponseMessage response = await _httpClient.PostAsync(values.url, content);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new Exception($"Failed to request SCEP certificate: {response.StatusCode} " + await response.Content.ReadAsStringAsync());
+            }
+            byte[] responseBytes = await response.Content.ReadAsByteArrayAsync();
+            return DecodeAndInstallSCEPCertificate(responseBytes, rsaKeyPair, caCertificate, nonceBytes, cert, values.LocalCertStore);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error Requesting SCEP certificate");
+            Console.WriteLine("Error Requesting SCEP certificate: " + ex.Message);
+            return 1;
+        }
+    }
+
+    private int DecodeAndInstallSCEPCertificate(byte[] responseBytes, AsymmetricCipherKeyPair rsaKeyPair, 
+        X509Certificate2 caCertificate, byte[] nonce, X509Certificate2 signingCert, bool localStore)
+    {
+        var signedResponse = new SignedCms();
+        signedResponse.Decode(responseBytes);
+        X509Certificate2Collection caCerts =
+        [
+            caCertificate
+        ];
+        signedResponse.CheckSignature(caCerts, true);
+        var attributes = signedResponse
+            .SignerInfos
+            .Cast<SignerInfo>()
+            .SelectMany(si => si.SignedAttributes.Cast<CryptographicAttributeObject>());
+        var recipientNonce = attributes.FirstOrDefault(a => a.Oid.Value =="2.16.840.1.113733.1.9.6");
+        if (recipientNonce == null)
+        {
+            throw new Exception("Recipient nonce not found in response");
+        }
+        if (!nonce.SequenceEqual(recipientNonce.Values[0].RawData[2..]))
+        {
+            throw new Exception("Recipient nonce does not match");
+        }
+        var certBytes = signedResponse.ContentInfo.Content;
+        var cmsResponse = new EnvelopedCms();
+        cmsResponse.Decode(signedResponse.ContentInfo.Content);
+        cmsResponse.Decrypt(new X509Certificate2Collection(signingCert));
+        X509Certificate2Collection certCollection = new X509Certificate2Collection();
+        certCollection.Import(cmsResponse.ContentInfo.Content);
+        X509Certificate2 cert = certCollection.Last();
+        RSA rsaPrivateKey = DotNetUtilities.ToRSA((RsaPrivateCrtKeyParameters)rsaKeyPair.Private);
+        cert = cert.CopyWithPrivateKey(rsaPrivateKey);
+        WindowsCertStoreService.InstallFullCertificate(cert, localStore);
+        return 0;
+    }
+    
+    private static X509Certificate2 GenerateSelfSignedCertificate(AsymmetricCipherKeyPair keyPair, string subjectName, int validDays =2)
+    {
+        // Create the certificate generator
+        X509V3CertificateGenerator certGen = new X509V3CertificateGenerator();
+
+        // Set certificate subject and issuer (self-signed so issuer is the same as the subject)
+        X509Name issuerName = new X509Name($"CN={subjectName}");
+        certGen.SetIssuerDN(issuerName);
+        certGen.SetSubjectDN(issuerName);
+
+        // Set the certificate's serial number
+        BigInteger serialNumber = BigInteger.ProbablePrime(120, new SecureRandom());
+        certGen.SetSerialNumber(serialNumber);
+
+        // Set the certificate's validity period
+        DateTime notBefore = DateTime.UtcNow.Date;
+        DateTime notAfter = notBefore.AddDays(validDays);
+        certGen.SetNotBefore(notBefore);
+        certGen.SetNotAfter(notAfter);
+
+        // Set the public key for the certificate
+        certGen.SetPublicKey(keyPair.Public);
+
+        // Optionally add extensions (like Basic Constraints, Key Usage, etc.)
+        certGen.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(true));  // Cert is allowed to act as a CA
+
+        // Sign the certificate with the private key
+        ISignatureFactory signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private);
+        X509Certificate bouncyCastleCert = certGen.Generate(signatureFactory);
+        X509Certificate2 cert = new X509Certificate2(bouncyCastleCert.GetEncoded());
+        RSA rsaPrivateKey = DotNetUtilities.ToRSA((RsaPrivateCrtKeyParameters)keyPair.Private);
+        cert = cert.CopyWithPrivateKey(rsaPrivateKey);
+        return cert;
+    }
+    
+    private Pkcs10CertificationRequest CreateCSRForScep(SCEPArgModel values,
+        string challengePassword, AsymmetricCipherKeyPair rsaKeyPair)
+    {
+        AttributePkcs scepPassword = new AttributePkcs(PkcsObjectIdentifiers.Pkcs9AtChallengePassword, new DerSet(new DerPrintableString(challengePassword)));
+        X509ExtensionsGenerator extensions = new X509ExtensionsGenerator();
+        if (!string.IsNullOrWhiteSpace(values.SubjectAltNames))
+        {
+            GeneralNames subjectAlternateNames = new GeneralNames(
+                values.SubjectAltNames.Split(',').Select(dnsName => new GeneralName(GeneralName.DnsName, dnsName)).ToArray()
+            );
+            extensions.AddExtension(X509Extensions.SubjectAlternativeName, false, subjectAlternateNames);
+        }
+        AttributePkcs extensionRequest = new AttributePkcs(PkcsObjectIdentifiers.Pkcs9AtExtensionRequest, new DerSet(extensions.Generate()));
+        Asn1Encodable ekus = new ExtendedKeyUsage(values.EKUs.Select(oid => new DerObjectIdentifier(oid)).ToArray());
+        extensions.AddExtension(X509Extensions.ExtendedKeyUsage, false, ekus);
+        //key usage
+        extensions.AddExtension(
+            X509Extensions.KeyUsage,
+            true,
+            (
+                new KeyUsage(
+                    KeyUsage.KeyEncipherment
+                    | KeyUsage.DigitalSignature
+                    | KeyUsage.KeyCertSign
+                    | KeyUsage.CrlSign
+                )
+            ).ToAsn1Object()
+        );
+        Pkcs10CertificationRequest request = new Pkcs10CertificationRequest(
+            "SHA256WITHRSA",
+            new X509Name(values.SubjectName),
+            rsaKeyPair.Public,
+            new DerSet(extensionRequest, scepPassword),
+            rsaKeyPair.Private
+        );
+        return request;
+    }
+    
+    private static AsymmetricCipherKeyPair CreateKeyPair(string keyAlgo)
+    {
+        var randomGenerator = new CryptoApiRandomGenerator();
+        var random = new SecureRandom(randomGenerator);
+        if (keyAlgo.Contains("RSA", StringComparison.OrdinalIgnoreCase))
+        {
+            int strength = Int32.Parse(keyAlgo.Split(" ")[1]);
+            var keyGenerationParameters = new KeyGenerationParameters(random, strength);
+            var keyPairGenerator = new RsaKeyPairGenerator();
+            keyPairGenerator.Init(keyGenerationParameters);
+            return keyPairGenerator.GenerateKeyPair();
+        }
+        if (keyAlgo.Contains("ECDSA", StringComparison.OrdinalIgnoreCase))
+        {
+            var ecKeyPairGenerator = new ECKeyPairGenerator();
+            ECKeyGenerationParameters ecKeyGenParams;
+            if (keyAlgo.Contains("256"))
+            {
+                ecKeyGenParams = new(SecObjectIdentifiers.SecP256r1, new SecureRandom());
+            }
+            else if (keyAlgo.Contains("384"))
+            {
+                ecKeyGenParams = new(SecObjectIdentifiers.SecP384r1, new SecureRandom());
+            }
+            else
+            {
+                throw new NotImplementedException($"Algorithm {keyAlgo} not supported");
+            }
+            ecKeyPairGenerator.Init(ecKeyGenParams);
+            return ecKeyPairGenerator.GenerateKeyPair();
+        }
+        throw new NotImplementedException($"Algorithm {keyAlgo} not supported");
+    }
+    
+    private async Task<X509Certificate2> GetScepCA(string scepURL)
+    {
+        HttpResponseMessage caResponse  = await _httpClient.GetAsync(string.Concat(scepURL, "?operation=GetCACert&message=ca"));
+        if (caResponse.IsSuccessStatusCode)
+        {
+            byte[] caCertData = await caResponse.Content.ReadAsByteArrayAsync();
+            X509Certificate2 caCert =  new (caCertData);
+            // Validate the chain to ensure we trust the CA
+            X509Chain chain = new();
+            if (chain.Build(caCert))
+            {
+                return caCert;
+            }
+            throw new Exception("Error building chain for SCEP CA certificate: " + chain.ChainStatus[0].StatusInformation);
+        }
+        throw new Exception("Error getting SCEP CA certificate: " + await caResponse.Content.ReadAsStringAsync());
     }
 
     private string GetComputerSubjectName()

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/CreateDCCertificate.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/CreateDCCertificate.cs
@@ -76,16 +76,16 @@ public class CreateDCCertificate
         HelpText = "Use Azure CLI as authentication method"
     )]
     public bool AzureCLI { get; set; } = false;
-    
-    [Option('k', "KeyLength",  HelpText = "Certificate Key Length", Default = 4096)]
+
+    [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
     public int KeyLength { get; set; } = 4096;
+
     [Option(
         'p',
         "KeyProvider",
         Required = false,
         Default = "Microsoft Enhanced Cryptographic Provider v1.0",
-        HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
-            
+        HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)"
     )]
     public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
@@ -74,16 +74,16 @@ namespace DotNetCertAuthSample.Models
                 + "you Azure TenantID, the Application ID and the Application Secret"
         )]
         public string ClientSecret { get; set; } = "";
-        
+
         [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
         public int KeyLength { get; set; } = 4096;
+
         [Option(
             'p',
             "KeyProvider",
             Required = false,
             Default = "Microsoft Enhanced Cryptographic Provider v1.0",
-            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
-            
+            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)"
         )]
         public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
     }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
@@ -63,15 +63,16 @@ namespace DotNetCertAuthSample.Models
             HelpText = "Certificate Issuer Name"
         )]
         public string issuer { get; set; } = "";
+
         [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
         public int KeyLength { get; set; } = 4096;
+
         [Option(
             'p',
             "KeyProvider",
             Required = false,
             Default = "Microsoft Enhanced Cryptographic Provider v1.0",
-            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)" 
-            
+            HelpText = "Certificate Key Provider (Default: Microsoft Enhanced Cryptographic Provider v1.0)"
         )]
         public string KeyProvider { get; set; } = "Microsoft Enhanced Cryptographic Provider v1.0";
     }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
@@ -1,0 +1,72 @@
+using CommandLine;
+using EZCAClient.Models;
+
+namespace DotNetCertAuthSample.Models;
+
+[Verb(
+    "SCEPCertificate",
+    HelpText = "Creates a new SCEP certificate using SCEP Static Challenge protocol"
+)]
+public class SCEPArgModel
+{
+    [Option(
+        "LocalStore",
+        Required = false,
+        Default = true,
+        HelpText = "If the certificate should be stored in the computers Local Store. If false certificate will be stored in the user store"
+    )]
+    public bool LocalCertStore { get; set; } = true;
+    
+    [Option(
+        "EKUs",
+        Required = false,
+        
+        
+        Default = "1.3.6.1.5.5.7.3.2,1.3.6.1.5.5.7.3.1",
+        HelpText = "EKUs requested for the certificate"
+    )]
+    public string? EKUsInputs { get; set; }
+    public List<string> EKUs { get; set; } = [EZCAConstants.ClientAuthenticationEKU, EZCAConstants.ServerAuthenticationEKU];
+    
+    [Option('k', "KeyLength",  HelpText = "Certificate Key Length", Default = 4096)]
+    public int KeyLength { get; set; } = 4096;
+    
+    [Option(
+        "AppInsights",
+        Required = false,
+        HelpText = "Azure Application Insights connection string to send logs to"
+    )]
+    public string? AppInsightsKey { get; set; }
+
+    [Option(
+        'u',
+        "URL",
+        Required = true,
+        HelpText = "SCEP URL from your EZCA CA"
+    )]
+    public string? url { get; set; }
+    
+    
+    [Option(
+        's',
+        "SubjectName",
+        Required = false,
+        HelpText = "Subject Name for this certificate for example: CN=server1.contoso.com OU=Domain Controllers DC=contoso DC=com"
+    )]
+    public string? SubjectName { get; set; }
+    
+    [Option(
+        'p',
+        "SCEPPassword",
+        Required = true,
+        HelpText = "SCEP Password for Static Challenge"
+    )]
+    public string? SCEPPassword { get; set; }
+    
+    [Option(
+        "SubjectAltNames",
+        Required = false,
+        HelpText = "Subject Alternate Names for this certificate for example (comma separate multiple): server1.constoso.com,server2.contoso.com"
+    )]
+    public string? SubjectAltNames { get; set; }
+}

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
@@ -16,21 +16,20 @@ public class SCEPArgModel
         HelpText = "If the certificate should be stored in the computers Local Store. If false certificate will be stored in the user store"
     )]
     public bool LocalCertStore { get; set; } = true;
-    
+
     [Option(
         "EKUs",
         Required = false,
-        
-        
         Default = "1.3.6.1.5.5.7.3.2,1.3.6.1.5.5.7.3.1",
         HelpText = "EKUs requested for the certificate"
     )]
     public string? EKUsInputs { get; set; }
-    public List<string> EKUs { get; set; } = [EZCAConstants.ClientAuthenticationEKU, EZCAConstants.ServerAuthenticationEKU];
-    
-    [Option('k', "KeyLength",  HelpText = "Certificate Key Length", Default = 4096)]
+    public List<string> EKUs { get; set; } =
+        [EZCAConstants.ClientAuthenticationEKU, EZCAConstants.ServerAuthenticationEKU];
+
+    [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
     public int KeyLength { get; set; } = 4096;
-    
+
     [Option(
         "AppInsights",
         Required = false,
@@ -38,15 +37,9 @@ public class SCEPArgModel
     )]
     public string? AppInsightsKey { get; set; }
 
-    [Option(
-        'u',
-        "URL",
-        Required = true,
-        HelpText = "SCEP URL from your EZCA CA"
-    )]
+    [Option('u', "URL", Required = true, HelpText = "SCEP URL from your EZCA CA")]
     public string? url { get; set; }
-    
-    
+
     [Option(
         's',
         "SubjectName",
@@ -54,15 +47,10 @@ public class SCEPArgModel
         HelpText = "Subject Name for this certificate for example: CN=server1.contoso.com OU=Domain Controllers DC=contoso DC=com"
     )]
     public string? SubjectName { get; set; }
-    
-    [Option(
-        'p',
-        "SCEPPassword",
-        Required = true,
-        HelpText = "SCEP Password for Static Challenge"
-    )]
+
+    [Option('p', "SCEPPassword", Required = true, HelpText = "SCEP Password for Static Challenge")]
     public string? SCEPPassword { get; set; }
-    
+
     [Option(
         "SubjectAltNames",
         Required = false,

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Program.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Program.cs
@@ -7,7 +7,7 @@ namespace DotNetCertAuthSample;
 
 public class Program
 {
-    public static async Task Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         CertificateManager certificateManager = new();
         int result = Parser
@@ -15,18 +15,21 @@ public class Program
                 RenewArgModel,
                 GenerateArgModel,
                 RegisterArgModel,
-                CreateDCCertificate
+                CreateDCCertificate,
+                SCEPArgModel
             >(args)
             .MapResult(
                 (RenewArgModel operation) => certificateManager.InitializeManager(operation),
                 (GenerateArgModel operation) => certificateManager.InitializeManager(operation),
                 (RegisterArgModel operation) => certificateManager.InitializeManager(operation),
                 (CreateDCCertificate operation) => certificateManager.InitializeManager(operation),
+                (SCEPArgModel operation) => certificateManager.InitializeManager(operation),
                 errs => certificateManager.ProcessError(errs)
             );
         if (result == 0)
         {
-            await certificateManager.CallCertActionAsync();
+            result = await certificateManager.CallCertActionAsync();
         }
+        return result;
     }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "DotNetCertAuthSample": {
       "commandName": "Project",
 //      "commandLineArgs": " renew -s \"CN=server3.contoso.com\" -i \"SCEP Any Root  Extras\" --LocalStore --EZCAInstance https://localhost:5001/ -k 2048" //https://ezcaeastuswin-testslot.azurewebsites.net/ "
-     "commandLineArgs": "createDC  -s \"CN=server3.contoso.com-tpm\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  -p \"Microsoft Platform Crypto Provider\" --EZCAInstance https://localhost:5001/"
+//      "commandLineArgs": "createDC  -s \"CN=server3.contoso.com-tpm\" --caid 077cfd01-82ee-40bd-b709-f0f9b9d8f996  -k 2048  --TemplateID e04ee1d3-d8bf-45c8-9f66-374015555c3e -v 20 -g 5a301941-1a9c-479f-ac56-19201d4b437f  -p \"Microsoft Platform Crypto Provider\" --EZCAInstance https://localhost:5001/",
+      "commandLineArgs": "SCEPCertificate  -u https://portal.ezca.io/api/SCEP/Static/1c3c6cea-fcbd-4681-85e1-74fb74b6863e/d2e20719-090c-40c9-88a0-71955e474f73/eastus/cgi-bin -s \"CN=server3.contoso.com\" -p YOURPASSWORD  --SubjectAltNames igal "
     }
   }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/DerEncoding.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/DerEncoding.cs
@@ -2,7 +2,6 @@ using System.Text;
 
 namespace DotNetCertAuthSample.Services;
 
-
 public static class DerEncoding
 {
     /// <summary>

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/DerEncoding.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/DerEncoding.cs
@@ -1,0 +1,54 @@
+using System.Text;
+
+namespace DotNetCertAuthSample.Services;
+
+
+public static class DerEncoding
+{
+    /// <summary>
+    /// PrintableString: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540812%28v=vs.85%29.aspx
+    /// </summary>
+    public static byte[] EncodePrintableString(string data)
+    {
+        var dataBytes = Encoding.ASCII.GetBytes(data);
+
+        return getDerBytes(0x13, dataBytes);
+    }
+
+    /// <summary>
+    /// Integer: https://msdn.microsoft.com/en-us/library/windows/desktop/bb540806%28v=vs.85%29.aspx
+    /// </summary>
+    public static byte[] EncodeInteger(int data)
+    {
+        if (data > byte.MaxValue)
+        {
+            throw new NotSupportedException(
+                "Support for integers greater than 255 not yet implemented."
+            );
+        }
+
+        var dataBytes = new byte[] { (byte)data };
+        return getDerBytes(0x02, dataBytes);
+    }
+
+    /// <summary>
+    /// Octet: https://msdn.microsoft.com/en-us/library/windows/desktop/bb648644%28v=vs.85%29.aspx
+    /// </summary>
+    public static byte[] EncodeOctet(byte[] data)
+    {
+        return getDerBytes(0x04, data);
+    }
+
+    private static byte[] getDerBytes(int tag, byte[] data)
+    {
+        if (data.Length > byte.MaxValue)
+        {
+            throw new NotSupportedException(
+                "Support for integers greater than 255 not yet implemented."
+            );
+        }
+
+        var header = new byte[] { (byte)tag, (byte)data.Length };
+        return header.Concat(data).ToArray();
+    }
+}

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
@@ -151,6 +151,7 @@ namespace DotNetCertAuthSample.Services
                 x509ExtensionEnhancedKeyUsage.InitializeEncode(objectIds);
                 certRequest.X509Extensions.Add((CX509Extension)x509ExtensionEnhancedKeyUsage);
             }
+           
             certRequest.Encode();
             return certRequest;
         }
@@ -169,6 +170,14 @@ namespace DotNetCertAuthSample.Services
                 EncodingType.XCN_CRYPT_STRING_BASE64HEADER,
                 null
             );
+        }
+        
+        public static void InstallFullCertificate(X509Certificate2 certificate, bool localStore)
+        {
+            X509Store store = new(localStore ? StoreLocation.LocalMachine : StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadWrite);
+            store.Add(certificate);
+            store.Close();
         }
 
         private static CX509ExtensionAlternativeNames CreateSans(List<string> sans)

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
@@ -43,8 +43,11 @@ namespace DotNetCertAuthSample.Services
                         .Find(X509FindType.FindByIssuerName, issuerName, true)
                         .FirstOrDefault();
                 }
-                cert ??= certs.OrderByDescending(x => x.NotAfter).FirstOrDefault(i => 
-                    i.SubjectName.Name == $"CN={subjectName}") ?? certs.OrderByDescending(x => x.NotAfter).First();
+                cert ??=
+                    certs
+                        .OrderByDescending(x => x.NotAfter)
+                        .FirstOrDefault(i => i.SubjectName.Name == $"CN={subjectName}")
+                    ?? certs.OrderByDescending(x => x.NotAfter).First();
             }
             else
             {
@@ -71,8 +74,11 @@ namespace DotNetCertAuthSample.Services
                 }
                 else if (matchingCertificates.Count > 1)
                 {
-                    cert = matchingCertificates.OrderByDescending(x => x.NotAfter).FirstOrDefault(i => 
-                        i.SubjectName.Name == $"CN={subjectName}") ?? matchingCertificates.OrderByDescending(x => x.NotAfter).First();
+                    cert =
+                        matchingCertificates
+                            .OrderByDescending(x => x.NotAfter)
+                            .FirstOrDefault(i => i.SubjectName.Name == $"CN={subjectName}")
+                        ?? matchingCertificates.OrderByDescending(x => x.NotAfter).First();
                 }
             }
             if (cert == null)
@@ -113,9 +119,11 @@ namespace DotNetCertAuthSample.Services
         )
         {
             CX509CertificateRequestPkcs10 certRequest = new();
-            certRequest.Initialize(localStore
-                ? X509CertificateEnrollmentContext.ContextMachine
-                : X509CertificateEnrollmentContext.ContextUser);
+            certRequest.Initialize(
+                localStore
+                    ? X509CertificateEnrollmentContext.ContextMachine
+                    : X509CertificateEnrollmentContext.ContextUser
+            );
             certRequest.PrivateKey.ExportPolicy =
                 X509PrivateKeyExportFlags.XCN_NCRYPT_ALLOW_EXPORT_NONE;
             certRequest.PrivateKey.Length = keylength;
@@ -151,7 +159,7 @@ namespace DotNetCertAuthSample.Services
                 x509ExtensionEnhancedKeyUsage.InitializeEncode(objectIds);
                 certRequest.X509Extensions.Add((CX509Extension)x509ExtensionEnhancedKeyUsage);
             }
-           
+
             certRequest.Encode();
             return certRequest;
         }
@@ -171,10 +179,11 @@ namespace DotNetCertAuthSample.Services
                 null
             );
         }
-        
+
         public static void InstallFullCertificate(X509Certificate2 certificate, bool localStore)
         {
-            X509Store store = new(localStore ? StoreLocation.LocalMachine : StoreLocation.CurrentUser);
+            X509Store store =
+                new(localStore ? StoreLocation.LocalMachine : StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadWrite);
             store.Add(certificate);
             store.Close();

--- a/README.md
+++ b/README.md
@@ -136,5 +136,30 @@ Sample call:
 Same as the other commands, if you want to serve this certificate when a computer tries to RDP to this endpoint, we must add ```--LocalStore -r```:
 ```.\EZCACertManager.exe renew -s mydomain.com --LocalStore -r```
 
+## How to Create SCEP Certificates for Non-Managed Windows Devices
+If you are migrating to the cloud but not all of your devices are cloud managed or MDM managed, you can use this client to request certificates from EZCA using static SCEP for those devices. To Request a Static SCEP certificate, you will need your Static SCEP URL from EZCA, and the Static Challenge, you can find this information in the EZCA portal under the Certificate Authority details.
+```
+   --LocalStore          (Default: true) If the certificate should be stored in the computers Local Store. If false
+                        certificate will be stored in the user store
+
+  --EKUs                (Default: 1.3.6.1.5.5.7.3.2,1.3.6.1.5.5.7.3.1) EKUs requested for the certificate
+
+  -k, --KeyLength       (Default: 4096) Certificate Key Length
+
+  --AppInsights         Azure Application Insights connection string to send logs to
+
+  -u, --URL             Required. SCEP URL from your EZCA CA
+
+  -s, --SubjectName     Subject Name for this certificate for example: CN=server1.contoso.com OU=Domain Controllers
+                        DC=contoso DC=com (If left empty it will use the computer name in your domain)
+
+  -p, --SCEPPassword    Required. SCEP Password for Static Challenge
+
+  --SubjectAltNames     Subject Alternate Names for this certificate for example (comma separate multiple):
+                        server1.constoso.com,server2.contoso.com (If left empty it will use the computer name in your domain)
+```
+Sample call:
+```.\EZCACertManager.exe SCEPCertificate  -u https://portal.ezca.io/api/SCEP/Static/1c3c6cea-fcbd-4681-85e1-74fb74b6863e/d2e20719-090c-40c9-88a0-d1955ed74f73/eastus/cgi-bin -s "CN=server3.contoso.com" -p YOURPASSWORD  --SubjectAltNames machine.contoso.com,machine2.contoso.com  ```
+
 ## Download Signed Binary 
 https://download.keytos.io/Downloads/CertificateManager/EZCACertManager.exe 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Same as the other commands, if you want to serve this certificate when a compute
 
 ## How to Create SCEP Certificates for Non-Managed Windows Devices
 If you are migrating to the cloud but not all of your devices are cloud managed or MDM managed, you can use this client to request certificates from EZCA using static SCEP for those devices. To Request a Static SCEP certificate, you will need your Static SCEP URL from EZCA, and the Static Challenge, you can find this information in the EZCA portal under the Certificate Authority details.
+![How To Enable Static SCEP](https://github.com/user-attachments/assets/671f54bc-0669-40ab-a1e0-977fce493d22)
+
 ```
    --LocalStore          (Default: true) If the certificate should be stored in the computers Local Store. If false
                         certificate will be stored in the user store


### PR DESCRIPTION
++

This pull request adds the functionality to issue SCEP certificates. It includes the following changes:

- Added a new command-line argument model for SCEP certificate creation.

- Created a new service for encoding DER data.

- Updated the `Program` class to handle the new SCEP certificate creation command.

- Added a new model for the SCEP certificate creation command.

- Updated the README file with instructions on how to create SCEP certificates for non-managed Windows devices.
