### PR TITLE
Add environment variable support for SCEP passwords

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -948,11 +948,15 @@ public class CertificateManager(
             throw new ArgumentNullException(nameof(values.url));
         }
 
-        // TIP: you can hardcode the password here or use a secure secret manager to avoid having the password in the Script
-        // values.SCEPPassword = "YourPassword";
         if (string.IsNullOrWhiteSpace(values.SCEPPassword))
         {
-            throw new ArgumentNullException(nameof(values.SCEPPassword));
+            values.SCEPPassword = Environment.GetEnvironmentVariable("EZCA_SCEP_PASSWORD");
+        }
+        if (string.IsNullOrWhiteSpace(values.SCEPPassword))
+        {
+            throw new ArgumentException(
+                "SCEP password is required. Provide it via -p / --SCEPPassword or set the EZCA_SCEP_PASSWORD environment variable."
+            );
         }
     }
 

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
@@ -48,7 +48,12 @@ public class SCEPArgModel
     )]
     public string? SubjectName { get; set; }
 
-    [Option('p', "SCEPPassword", Required = true, HelpText = "SCEP Password for Static Challenge")]
+    [Option(
+        'p',
+        "SCEPPassword",
+        Required = false,
+        HelpText = "SCEP Password for Static Challenge. Can also be set via the EZCA_SCEP_PASSWORD environment variable to avoid exposing the password in the process command line."
+    )]
     public string? SCEPPassword { get; set; }
 
     [Option(


### PR DESCRIPTION
Instead of collecting the SCEP password as a command-line option you can now also set it as an environment variable.

This way it won't leak in Task Manager.