### PR TITLE
feat: added IIS binding support

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample.Test/IISBindingMatchingTests.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample.Test/IISBindingMatchingTests.cs
@@ -1,0 +1,127 @@
+#if WINDOWS
+using DotNetCertAuthSample.Services;
+using EZCAClient.Models;
+using Xunit;
+
+namespace DotNetCertAuthSample.Test;
+
+/// <summary>
+/// Offline unit tests for the IIS binding selection. When no site is named on the
+/// command line the client only rebinds the https bindings whose host name the
+/// certificate actually covers, so this matching decides which sites are touched.
+/// </summary>
+public class IISBindingMatchingTests
+{
+    [Theory]
+    [InlineData("www.contoso.com", "www.contoso.com")]
+    [InlineData("WWW.CONTOSO.COM", "www.contoso.com")]
+    [InlineData("www.contoso.com", "WWW.CONTOSO.COM")]
+    public void CertificateCoversHost_MatchesExactNameIgnoringCase(
+        string certificateName,
+        string host
+    )
+    {
+        Assert.True(WindowsSystemInfoService.CertificateCoversHost([certificateName], host));
+    }
+
+    [Theory]
+    [InlineData("*.contoso.com", "www.contoso.com")]
+    [InlineData("*.contoso.com", "api.contoso.com")]
+    public void CertificateCoversHost_MatchesSingleLabelUnderWildcard(
+        string certificateName,
+        string host
+    )
+    {
+        Assert.True(WindowsSystemInfoService.CertificateCoversHost([certificateName], host));
+    }
+
+    [Theory]
+    [InlineData("*.contoso.com", "a.b.contoso.com")] // wildcards only cover one label
+    [InlineData("*.contoso.com", "contoso.com")]
+    [InlineData("www.contoso.com", "www.fabrikam.com")]
+    [InlineData("www.contoso.com", "notwww.contoso.com")]
+    public void CertificateCoversHost_RejectsNamesOutsideTheCertificate(
+        string certificateName,
+        string host
+    )
+    {
+        Assert.False(WindowsSystemInfoService.CertificateCoversHost([certificateName], host));
+    }
+
+    [Fact]
+    public void CertificateCoversHost_MatchesAnyOfTheCertificateNames()
+    {
+        string[] names = ["contoso.com", "www.contoso.com", "*.dev.contoso.com"];
+        Assert.True(WindowsSystemInfoService.CertificateCoversHost(names, "www.contoso.com"));
+        Assert.True(WindowsSystemInfoService.CertificateCoversHost(names, "api.dev.contoso.com"));
+        Assert.False(WindowsSystemInfoService.CertificateCoversHost(names, "www.fabrikam.com"));
+    }
+
+    /// <summary>
+    /// A binding with no host name answers every request that reaches its ip and port,
+    /// so it is never picked up by name matching. Those need an explicit --IISSite.
+    /// </summary>
+    [Fact]
+    public void CertificateCoversHost_DoesNotMatchCatchAllBinding()
+    {
+        Assert.False(WindowsSystemInfoService.CertificateCoversHost(["www.contoso.com"], ""));
+    }
+
+    [Fact]
+    public void CertificateCoversHost_IgnoresEmptyCertificateNames()
+    {
+        Assert.False(WindowsSystemInfoService.CertificateCoversHost(["", "  "], "www.contoso.com"));
+    }
+
+    /// <summary>
+    /// renewAll calls into IIS for every renewed certificate, so a machine without IIS
+    /// has to be reported as "nothing to do" rather than failing the renewal.
+    /// </summary>
+    [Fact]
+    public void CheckIfIISCertAndRenew_IsANoOpWhenIISIsNotInstalled()
+    {
+        if (IsIISInstalled())
+        {
+            return;
+        }
+
+        WindowsSystemInfoService service = new();
+        APIResultModel result = service.CheckIfIISCertAndRenew(
+            new string('A', 40),
+            new string('B', 40)
+        );
+        Assert.True(result.Success);
+        Assert.Empty(result.Message);
+    }
+
+    [Fact]
+    public void SetIISCertificate_ReportsWhenIISIsNotInstalled()
+    {
+        if (IsIISInstalled())
+        {
+            return;
+        }
+
+        WindowsSystemInfoService service = new();
+        APIResultModel result = service.SetIISCertificate(
+            new string('A', 40),
+            null,
+            ["www.contoso.com"]
+        );
+        Assert.False(result.Success);
+        Assert.Contains("IIS is not installed", result.Message);
+    }
+
+    private static bool IsIISInstalled()
+    {
+        return File.Exists(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.System),
+                "inetsrv",
+                "config",
+                "applicationHost.config"
+            )
+        );
+    }
+}
+#endif

--- a/DotNetCertAuthSample/DotNetCertAuthSample/DotNetCertAuthSample.csproj
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/DotNetCertAuthSample.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.5" />
   </ItemGroup>
 </Project>

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -280,6 +280,19 @@ public class CertificateManager(
                 {
                     LogError(new(rdpResult.Message));
                 }
+
+                APIResultModel iisResult = systemInfoService.CheckIfIISCertAndRenew(
+                    cert.Thumbprint,
+                    certReturned.Thumbprint
+                );
+                if (iisResult.Success && !string.IsNullOrWhiteSpace(iisResult.Message))
+                {
+                    LogInformation(iisResult.Message);
+                }
+                else if (!iisResult.Success)
+                {
+                    LogError(new(iisResult.Message));
+                }
             }
             settings.RotatedCertificates.Add(new(cert.Thumbprint, cert.NotAfter));
             settingsService.SaveSettings(settings, _logger);
@@ -384,6 +397,12 @@ public class CertificateManager(
                 SetRDPCertificate(
                     CryptoStaticService.ImportCertFromPEMString(createdCert).Thumbprint
                 );
+            }
+
+            if (values.IISCert)
+            {
+                LogInformation($"Setting IIS certificate");
+                SetIISCertificate(certReturned, values.IISSite);
             }
 
             await CheckAndSaveCertificateToPathAsync(
@@ -606,6 +625,7 @@ public class CertificateManager(
     private void AssertCorrectRenewArgModel(RenewArgModel values)
     {
         AssertRdpSupported(values.RDPCert, values.LocalCertStore);
+        AssertIisSupported(values.IISCert, values.IISSite, values.LocalCertStore);
         AssertLocalStoreProperties(values.LocalCertStore);
 
         if (
@@ -639,6 +659,31 @@ public class CertificateManager(
         {
             throw new ArgumentException(
                 "If certificate will be used for RDP it must be stored in the local store"
+            );
+        }
+    }
+
+    private static void AssertIisSupported(bool iisCert, string? iisSite, bool localCertStore)
+    {
+        if (!iisCert)
+        {
+            if (!string.IsNullOrWhiteSpace(iisSite))
+            {
+                throw new ArgumentException("--IISSite can only be used together with --IIS");
+            }
+
+            return;
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new ArgumentException("IIS certificates are only supported on Windows");
+        }
+
+        if (!localCertStore)
+        {
+            throw new ArgumentException(
+                "If certificate will be used for IIS it must be stored in the local store"
             );
         }
     }
@@ -686,6 +731,12 @@ public class CertificateManager(
             {
                 SetRDPCertificate(createdCertificate.Thumbprint);
             }
+
+            if (values.IISCert)
+            {
+                LogInformation($"Setting IIS certificate");
+                SetIISCertificate(createdCertificate, values.IISSite);
+            }
         }
         catch (Exception ex)
         {
@@ -699,6 +750,7 @@ public class CertificateManager(
     private void ValidateGenerateArgModel(GenerateArgModel values)
     {
         AssertRdpSupported(values.RDPCert, values.LocalCertStore);
+        AssertIisSupported(values.IISCert, values.IISSite, values.LocalCertStore);
         AssertLocalStoreProperties(values.LocalCertStore);
         AssertCertificatePathProperties(values.Path);
         if (!IsGuid(values.caID))
@@ -1420,6 +1472,40 @@ public class CertificateManager(
     private void SetRDPCertificate(string thumbprint)
     {
         systemInfoService.SetRDPCertificate(thumbprint);
+    }
+
+    private void SetIISCertificate(X509Certificate2 certificate, string? siteName)
+    {
+        APIResultModel result = systemInfoService.SetIISCertificate(
+            certificate.Thumbprint,
+            siteName,
+            GetCertificateHostNames(certificate)
+        );
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(result.Message);
+        }
+
+        LogInformation(result.Message);
+    }
+
+    private static List<string> GetCertificateHostNames(X509Certificate2 certificate)
+    {
+        List<string> hostNames = GetSubjectAlternativeNames(certificate)
+            .Where(i => i.Type == SANTypes.DNSName)
+            .Select(i => i.Value)
+            .ToList();
+        // certificates issued without SANs only carry the host name in the common name
+        string commonName = certificate.GetNameInfo(X509NameType.SimpleName, false);
+        if (
+            !string.IsNullOrWhiteSpace(commonName)
+            && !hostNames.Contains(commonName, StringComparer.OrdinalIgnoreCase)
+        )
+        {
+            hostNames.Add(commonName);
+        }
+
+        return hostNames;
     }
 
     private async Task<X509Certificate2> CreateCertificateAsync(

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/GenerateArgModel.cs
@@ -14,6 +14,21 @@ public class GenerateArgModel
     )]
     public bool RDPCert { get; set; }
 
+    [Option(
+        "IIS",
+        Required = false,
+        Default = false,
+        HelpText = "whether this certificate should be bound to the machine's IIS https bindings. Requires --LocalStore"
+    )]
+    public bool IISCert { get; set; }
+
+    [Option(
+        "IISSite",
+        Required = false,
+        HelpText = "Name of the IIS site to bind the certificate to. Only valid with --IIS. If omitted, the certificate is bound to every IIS https binding whose host name it covers"
+    )]
+    public string? IISSite { get; set; }
+
     [Option('d', "Domain", HelpText = "Domain for the certificate you want to create")]
     public string? Domain { get; set; }
 

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
@@ -15,6 +15,21 @@ public class RenewArgModel
     public bool RDPCert { get; set; }
 
     [Option(
+        "IIS",
+        Required = false,
+        Default = false,
+        HelpText = "whether this certificate should be bound to the machine's IIS https bindings. Requires --LocalStore"
+    )]
+    public bool IISCert { get; set; }
+
+    [Option(
+        "IISSite",
+        Required = false,
+        HelpText = "Name of the IIS site to bind the certificate to. Only valid with --IIS. If omitted, the certificate is bound to every IIS https binding whose host name it covers"
+    )]
+    public string? IISSite { get; set; }
+
+    [Option(
         's',
         "SubjectName",
         Required = false,

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/ISystemInfoService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/ISystemInfoService.cs
@@ -8,4 +8,21 @@ public interface ISystemInfoService
 
     void SetRDPCertificate(string thumbprint);
     APIResultModel CheckIfRDPCertAndRenew(string oldCertThumbprint, string newCertThumbprint);
+
+    /// <summary>
+    /// Binds the certificate to the machine's IIS https bindings. When a site name is
+    /// given every https binding of that site is updated, otherwise only the bindings
+    /// whose host name is covered by the certificate are updated.
+    /// </summary>
+    APIResultModel SetIISCertificate(
+        string thumbprint,
+        string? siteName,
+        IReadOnlyList<string> certificateHostNames
+    );
+
+    /// <summary>
+    /// Updates every IIS https binding that is currently using the old certificate so
+    /// that it uses the renewed one. Bindings using other certificates are left alone.
+    /// </summary>
+    APIResultModel CheckIfIISCertAndRenew(string oldCertThumbprint, string newCertThumbprint);
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/UnifiedSystemInfoService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/UnifiedSystemInfoService.cs
@@ -18,4 +18,18 @@ public class UnifiedSystemInfoService : ISystemInfoService
     {
         throw new NotSupportedException("RDP is only available on Windows");
     }
+
+    public APIResultModel SetIISCertificate(
+        string thumbprint,
+        string? siteName,
+        IReadOnlyList<string> certificateHostNames
+    )
+    {
+        throw new NotSupportedException("IIS is only available on Windows");
+    }
+
+    public APIResultModel CheckIfIISCertAndRenew(string oldCertThumbprint, string newCertThumbprint)
+    {
+        throw new NotSupportedException("IIS is only available on Windows");
+    }
 }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsSystemInfoService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsSystemInfoService.cs
@@ -2,14 +2,19 @@
 using System.DirectoryServices.AccountManagement;
 using System.Globalization;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using EZCAClient.Models;
 using Microsoft.Management.Infrastructure;
 using Microsoft.Management.Infrastructure.Options;
+using Microsoft.Web.Administration;
 
 namespace DotNetCertAuthSample.Services;
 
 public class WindowsSystemInfoService : ISystemInfoService
 {
+    private const string DefaultCertificateStoreName = "MY";
+    private const string HttpsProtocol = "https";
+
     public string? GetComputerDistinguishedName(string computerName)
     {
         try
@@ -96,7 +101,324 @@ public class WindowsSystemInfoService : ISystemInfoService
         return new(true, "RDP certificate updated successfully");
     }
 
+    public APIResultModel SetIISCertificate(
+        string thumbprint,
+        string? siteName,
+        IReadOnlyList<string> certificateHostNames
+    )
+    {
+        if (!IsIISInstalled())
+        {
+            return new(false, "IIS is not installed on this machine");
+        }
+        thumbprint = NormalizeThumbprint(thumbprint);
+        try
+        {
+            using ServerManager manager = new();
+            if (
+                !string.IsNullOrWhiteSpace(siteName)
+                && !manager.Sites.Any(site =>
+                    site.Name.Equals(siteName, StringComparison.OrdinalIgnoreCase)
+                )
+            )
+            {
+                return new(
+                    false,
+                    $"IIS site '{siteName}' was not found. {DescribeAvailableBindings(manager)}"
+                );
+            }
+            List<BindingTarget> targets = [];
+            List<string> centralCertStoreBindings = [];
+            foreach (Site site in manager.Sites)
+            {
+                if (
+                    !string.IsNullOrWhiteSpace(siteName)
+                    && !site.Name.Equals(siteName, StringComparison.OrdinalIgnoreCase)
+                )
+                {
+                    continue;
+                }
+                foreach (Binding binding in site.Bindings)
+                {
+                    if (!IsHttpsBinding(binding))
+                    {
+                        continue;
+                    }
+                    if (UsesCentralCertificateStore(binding))
+                    {
+                        centralCertStoreBindings.Add(Describe(site, binding));
+                        continue;
+                    }
+                    // an explicitly named site takes every https binding it has, otherwise we
+                    // only touch the bindings whose host name this certificate actually covers
+                    if (
+                        string.IsNullOrWhiteSpace(siteName)
+                        && !CertificateCoversHost(certificateHostNames, binding.Host)
+                    )
+                    {
+                        continue;
+                    }
+                    targets.Add(new(site, binding));
+                }
+            }
+            if (targets.Count == 0)
+            {
+                return new(false, NoBindingMessage(manager, siteName, centralCertStoreBindings));
+            }
+            APIResultModel storeCheck = CheckCertificateIsInStores(targets, thumbprint);
+            if (!storeCheck.Success)
+            {
+                return storeCheck;
+            }
+            foreach (BindingTarget target in targets)
+            {
+                ApplyCertificateToBinding(target.Binding, thumbprint);
+            }
+            manager.CommitChanges();
+            string message =
+                $"IIS certificate set successfully for {DescribeAll(targets)}"
+                + (
+                    centralCertStoreBindings.Count > 0
+                        ? $". Skipped {string.Join(", ", centralCertStoreBindings)} because they use the IIS Central Certificate Store"
+                        : string.Empty
+                );
+            return new(true, message);
+        }
+        catch (Exception ex)
+        {
+            return new(false, $"Error setting IIS certificate: {ex.Message}");
+        }
+    }
+
+    public APIResultModel CheckIfIISCertAndRenew(string oldCertThumbprint, string newCertThumbprint)
+    {
+        if (!IsIISInstalled())
+        {
+            return new(true, "");
+        }
+        oldCertThumbprint = NormalizeThumbprint(oldCertThumbprint);
+        newCertThumbprint = NormalizeThumbprint(newCertThumbprint);
+        try
+        {
+            using ServerManager manager = new();
+            List<BindingTarget> targets = [];
+            foreach (Site site in manager.Sites)
+            {
+                foreach (Binding binding in site.Bindings)
+                {
+                    if (!IsHttpsBinding(binding) || UsesCentralCertificateStore(binding))
+                    {
+                        continue;
+                    }
+                    if (GetBindingThumbprint(binding) == oldCertThumbprint)
+                    {
+                        targets.Add(new(site, binding));
+                    }
+                }
+            }
+            if (targets.Count == 0)
+            {
+                return new(true, "");
+            }
+            // a binding whose store does not hold the renewed certificate would be left
+            // pointing at nothing, so it is reported instead of being updated
+            List<BindingTarget> updatable = [];
+            List<string> unavailable = [];
+            foreach (BindingTarget target in targets)
+            {
+                if (IsCertificateInStore(GetBindingStoreName(target.Binding), newCertThumbprint))
+                {
+                    updatable.Add(target);
+                }
+                else
+                {
+                    unavailable.Add(
+                        $"{Describe(target.Site, target.Binding)} (LocalMachine\\{GetBindingStoreName(target.Binding)})"
+                    );
+                }
+            }
+            if (updatable.Count == 0)
+            {
+                return new(
+                    false,
+                    $"Could not update the IIS binding(s) {string.Join(", ", unavailable)} because the renewed "
+                        + $"certificate {newCertThumbprint} is not in the store those bindings read from"
+                );
+            }
+            foreach (BindingTarget target in updatable)
+            {
+                ApplyCertificateToBinding(target.Binding, newCertThumbprint);
+            }
+            manager.CommitChanges();
+            if (unavailable.Count > 0)
+            {
+                return new(
+                    false,
+                    $"IIS certificate updated successfully for {DescribeAll(updatable)}, but the binding(s) "
+                        + $"{string.Join(", ", unavailable)} were left unchanged because the renewed certificate "
+                        + $"{newCertThumbprint} is not in the store those bindings read from"
+                );
+            }
+            return new(true, $"IIS certificate updated successfully for {DescribeAll(updatable)}");
+        }
+        catch (Exception ex)
+        {
+            return new(false, $"Error updating IIS certificate: {ex.Message}");
+        }
+    }
+
+    private static bool IsIISInstalled()
+    {
+        string configPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "inetsrv",
+            "config",
+            "applicationHost.config"
+        );
+        return File.Exists(configPath);
+    }
+
+    private static bool IsHttpsBinding(Binding binding) =>
+        HttpsProtocol.Equals(binding.Protocol, StringComparison.OrdinalIgnoreCase);
+
+    private static bool UsesCentralCertificateStore(Binding binding) =>
+        binding.SslFlags.HasFlag(SslFlags.CentralCertStore);
+
+    private static string GetBindingStoreName(Binding binding) =>
+        string.IsNullOrWhiteSpace(binding.CertificateStoreName)
+            ? DefaultCertificateStoreName
+            : binding.CertificateStoreName;
+
+    private static string GetBindingThumbprint(Binding binding)
+    {
+        byte[]? hash = binding.CertificateHash;
+        return hash is null or { Length: 0 } ? string.Empty : Convert.ToHexString(hash);
+    }
+
+    private static void ApplyCertificateToBinding(Binding binding, string thumbprint)
+    {
+        // the store name has to be written before the hash, otherwise IIS drops it
+        binding.CertificateStoreName = GetBindingStoreName(binding);
+        binding.CertificateHash = Convert.FromHexString(thumbprint);
+    }
+
+    private static APIResultModel CheckCertificateIsInStores(
+        List<BindingTarget> targets,
+        string thumbprint
+    )
+    {
+        foreach (
+            string storeName in targets
+                .Select(target => GetBindingStoreName(target.Binding))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+        )
+        {
+            if (!IsCertificateInStore(storeName, thumbprint))
+            {
+                return new(
+                    false,
+                    $"Certificate {thumbprint} was not found in LocalMachine\\{storeName}, which is the store "
+                        + "the IIS binding(s) read from. Make sure the certificate is created with --LocalStore"
+                );
+            }
+        }
+        return new(true, "");
+    }
+
+    private static bool IsCertificateInStore(string storeName, string thumbprint)
+    {
+        try
+        {
+            using X509Store store = new(storeName, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadOnly);
+            return store.Certificates.Any(certificate =>
+                NormalizeThumbprint(certificate.Thumbprint) == thumbprint
+            );
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Matches an IIS binding host name against the names the certificate was issued for.
+    /// Bindings without a host name never match on their own, they need an explicit site.
+    /// </summary>
+    internal static bool CertificateCoversHost(
+        IReadOnlyList<string> certificateHostNames,
+        string host
+    )
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+        foreach (string name in certificateHostNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+            if (name.Equals(host, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            if (!name.StartsWith("*.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+            // a wildcard only covers a single label, *.contoso.com matches www.contoso.com
+            string suffix = name[1..];
+            if (
+                host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                && host.IndexOf('.') == host.Length - suffix.Length
+            )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string NoBindingMessage(
+        ServerManager manager,
+        string? siteName,
+        List<string> centralCertStoreBindings
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(siteName))
+        {
+            return centralCertStoreBindings.Count > 0
+                ? $"The IIS site '{siteName}' only has https bindings that use the Central Certificate Store, "
+                    + "those are managed by the store itself and cannot be bound to a thumbprint"
+                : $"The IIS site '{siteName}' does not have any https bindings";
+        }
+        return "No IIS https binding matched the names in this certificate. "
+            + $"Use --IISSite to pick the site to bind it to. {DescribeAvailableBindings(manager)}";
+    }
+
+    private static string DescribeAvailableBindings(ServerManager manager)
+    {
+        List<string> bindings = manager
+            .Sites.SelectMany(site =>
+                site.Bindings.Where(IsHttpsBinding).Select(binding => Describe(site, binding))
+            )
+            .ToList();
+        return bindings.Count == 0
+            ? "This machine does not have any IIS https bindings"
+            : $"Available https bindings: {string.Join(", ", bindings)}";
+    }
+
+    private static string DescribeAll(List<BindingTarget> targets) =>
+        string.Join(", ", targets.Select(target => Describe(target.Site, target.Binding)));
+
+    private static string Describe(Site site, Binding binding) =>
+        $"'{site.Name}' ({binding.BindingInformation})";
+
     private static string NormalizeThumbprint(string? thumbprint) =>
         (thumbprint ?? string.Empty).Replace(" ", string.Empty).Trim().ToUpperInvariant();
+
+    private readonly record struct BindingTarget(Site Site, Binding Binding);
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -14,14 +14,27 @@ This application can be used in combination with Windows Task Scheduler or Linux
 
 This application supports **Windows**, **Mac**, **Linux** platforms:
 
-- **Windows**: Uses Windows Certificate Store and Windows-specific APIs (CertEnroll, Active Directory, RDP configuration)
+- **Windows**: Uses Windows Certificate Store and Windows-specific APIs (CertEnroll, Active Directory, RDP configuration, IIS bindings)
 - **Linux**: Uses file-based certificate storage in `~/.local/share/keytos/certs` (user store) or `/etc/keytos/certs` (machine store)
 - **Mac**: Uses Mac Keychain Access
 
 **Note**: Some features are Windows-specific:
 - RDP certificate configuration (requires Windows)
+- IIS binding configuration (requires Windows with IIS installed)
 - Domain Controller certificate features (requires Active Directory)
 - Windows Certificate Store integration
+
+### IIS bindings
+
+`create` and `renew` accept `--IIS` to bind the new certificate to the machine's IIS https bindings. The certificate has to go to the machine store, so `--LocalStore` is required. By default only the bindings whose host name the certificate covers are updated; pass `--IISSite "<site name>"` to update every https binding of one site instead (this is what you want for a binding with no host name, such as the default `*:443:`).
+
+```powershell
+.\EZCACertManager.exe renew -s "www.contoso.com" --LocalStore --IIS
+```
+
+`renewAll` needs no flag. Every IIS https binding pointing at a certificate it renews is moved to the renewed certificate automatically, the same way RDP bindings are. Bindings that use the IIS Central Certificate Store are left alone, since those are managed by the store itself rather than by thumbprint.
+
+All of these need to run elevated, and IIS binding changes are written to `applicationHost.config`.
 
 ## Installation
 


### PR DESCRIPTION
## What

Adds IIS certificate binding to the client, following the same shape as the existing RDP support.

- `create` and `renew` take `--IIS` to bind the newly issued certificate, plus `--IISSite "<name>"` to scope it to a single site. `--IIS` requires `--LocalStore`.
- `renewAll` needs no flag. Every IIS https binding pointing at a certificate it renews is moved to the renewed certificate automatically, exactly like RDP bindings already are.

New `ISystemInfoService` members (`SetIISCertificate`, `CheckIfIISCertAndRenew`) implemented in `WindowsSystemInfoService` via `Microsoft.Web.Administration`, added to the `net10.0-windows` `ItemGroup` only. Non-Windows targets get `NotSupportedException` stubs, matching the RDP stubs.

## Why

Renewing a certificate for an IIS-hosted site previously left the site serving the old certificate until someone rebound it by hand in IIS Manager. `renewAll` under a scheduled task now closes that loop, which is the main reason to run this client unattended.

## Decisions worth reviewing

- **Which bindings `--IIS` touches.** Without `--IISSite`, only bindings whose host name the certificate covers (exact match, or a single-label wildcard) are updated — names come from the cert's DNS SANs plus its CN, so sanless certs still resolve. A binding with no host name (`*:443:`) never matches by name and needs an explicit `--IISSite`. If nothing matches, it fails and lists the available bindings rather than guessing.
- **Store name is preserved, not hardcoded** — `WebHosting` bindings stay on `WebHosting`.
- **Presence in the store is checked before `CommitChanges`.** In `renewAll`, a binding reading from a store that does not hold the renewed certificate (e.g. binding on `WebHosting` while the cert went to `My`) is skipped and reported instead of being pointed at a certificate that is not there. This is the case where a naive implementation takes a site offline.
- **Central Certificate Store bindings are skipped** and named in the result message, since they are resolved by the store rather than by thumbprint.
- **No IIS installed** is a clean error for `--IIS` and a silent no-op for `renewAll`, so existing non-IIS machines are unaffected.

## Testing

- Both target frameworks build; release single-file publish for `win-x64` verified (`Microsoft.Web.Administration` bundles into the exe, no loose DLL, no trimming/AOT in `build.ps1` to interfere).
- `IISBindingMatchingTests` added: host-matching rules (case-insensitivity, wildcard scope, catch-all exclusion) and the IIS-not-installed paths. Full offline suite passes, 24/24.
- Argument guards exercised against the built exe (`--IISSite` without `--IIS`, `--IIS` without `--LocalStore`).

⚠️ **The live IIS path is untested.** The dev machine has no IIS installed, so binding enumeration, the store-name-before-hash write order, and `CommitChanges` were never exercised against a real `applicationHost.config`. Please run this against a box with IIS and an https binding before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
