### PR TITLE
feat(renew): reuse the existing certificate's key length and hash

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample.Test/RenewalKeyAndHashTests.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample.Test/RenewalKeyAndHashTests.cs
@@ -1,0 +1,148 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using DotNetCertAuthSample.Services;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+using Xunit;
+using BouncyCastleCertificate = Org.BouncyCastle.X509.X509Certificate;
+
+namespace DotNetCertAuthSample.Test;
+
+/// <summary>
+/// Offline unit tests for the key length and hash algorithm a renewal inherits from the
+/// certificate being renewed.
+/// </summary>
+public class RenewalKeyAndHashTests
+{
+    private static X509Certificate2 CreateRsaCert(int keyLength, HashAlgorithmName hashAlgorithm)
+    {
+        using RSA rsa = RSA.Create(keyLength);
+        CertificateRequest request = new(
+            "CN=renewal-test",
+            rsa,
+            hashAlgorithm,
+            RSASignaturePadding.Pkcs1
+        );
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(1)
+        );
+    }
+
+    private static X509Certificate2 CreateEcdsaCert(ECCurve curve, HashAlgorithmName hashAlgorithm)
+    {
+        using ECDsa ecdsa = ECDsa.Create(curve);
+        CertificateRequest request = new("CN=renewal-test", ecdsa, hashAlgorithm);
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(1)
+        );
+    }
+
+    private static X509Certificate2 CreateSha1SignedCert()
+    {
+        RsaKeyPairGenerator keyPairGenerator = new();
+        keyPairGenerator.Init(new KeyGenerationParameters(new SecureRandom(), 2048));
+        AsymmetricCipherKeyPair keyPair = keyPairGenerator.GenerateKeyPair();
+
+        X509Name subject = new("CN=renewal-test");
+        X509V3CertificateGenerator certGenerator = new();
+        certGenerator.SetSerialNumber(BigInteger.One);
+        certGenerator.SetIssuerDN(subject);
+        certGenerator.SetSubjectDN(subject);
+        certGenerator.SetNotBefore(DateTimeOffset.UtcNow.AddDays(-1).UtcDateTime);
+        certGenerator.SetNotAfter(DateTimeOffset.UtcNow.AddYears(1).UtcDateTime);
+        certGenerator.SetPublicKey(keyPair.Public);
+
+        BouncyCastleCertificate generated = certGenerator.Generate(
+            new Asn1SignatureFactory("SHA1WITHRSA", keyPair.Private)
+        );
+        return X509CertificateLoader.LoadCertificate(generated.GetEncoded());
+    }
+
+    [Theory]
+    [InlineData(2048)]
+    [InlineData(3072)]
+    [InlineData(4096)]
+    public void GetKeyLength_Returns_Rsa_Key_Length(int keyLength)
+    {
+        using X509Certificate2 cert = CreateRsaCert(keyLength, HashAlgorithmName.SHA256);
+        Assert.Equal(keyLength, CertUtils.GetKeyLength(cert));
+    }
+
+    [Fact]
+    public void GetKeyLength_Returns_Ecdsa_Key_Length()
+    {
+        using X509Certificate2 cert = CreateEcdsaCert(
+            ECCurve.NamedCurves.nistP384,
+            HashAlgorithmName.SHA384
+        );
+        Assert.Equal(384, CertUtils.GetKeyLength(cert));
+    }
+
+    [Theory]
+    [InlineData("SHA256")]
+    [InlineData("SHA384")]
+    [InlineData("SHA512")]
+    public void GetHashAlgorithm_Returns_Rsa_Signature_Hash(string hashName)
+    {
+        HashAlgorithmName hashAlgorithm = new(hashName);
+        using X509Certificate2 cert = CreateRsaCert(2048, hashAlgorithm);
+        Assert.Equal(hashAlgorithm, CertUtils.GetHashAlgorithm(cert));
+    }
+
+    [Theory]
+    [InlineData("SHA256")]
+    [InlineData("SHA384")]
+    [InlineData("SHA512")]
+    public void GetHashAlgorithm_Returns_Ecdsa_Signature_Hash(string hashName)
+    {
+        HashAlgorithmName hashAlgorithm = new(hashName);
+        using X509Certificate2 cert = CreateEcdsaCert(ECCurve.NamedCurves.nistP256, hashAlgorithm);
+        Assert.Equal(hashAlgorithm, CertUtils.GetHashAlgorithm(cert));
+    }
+
+    [Fact]
+    public void GetHashAlgorithm_Falls_Back_To_Sha256_For_Weak_Hashes()
+    {
+        using X509Certificate2 cert = CreateSha1SignedCert();
+        Assert.Equal(HashAlgorithmName.SHA256, CertUtils.GetHashAlgorithm(cert));
+    }
+
+    [Theory]
+    [InlineData("SHA256", "1.2.840.113549.1.1.11")]
+    [InlineData("SHA384", "1.2.840.113549.1.1.12")]
+    [InlineData("SHA512", "1.2.840.113549.1.1.13")]
+    public void CreateCSR_Uses_Requested_Key_Length_And_Hash(
+        string hashName,
+        string expectedSignatureOid
+    )
+    {
+        UnifiedCertStoreService certStoreService = new(new UnifiedStoreService());
+        string csrPem = certStoreService.CreateCSR(
+            "CN=renewal-test",
+            ["renewal-test"],
+            2048,
+            false,
+            [],
+            string.Empty,
+            null,
+            false,
+            new HashAlgorithmName(hashName)
+        );
+
+        Pkcs10CertificationRequest csr = (Pkcs10CertificationRequest)
+            new PemReader(new StringReader(csrPem)).ReadObject();
+        Assert.Equal(expectedSignatureOid, csr.SignatureAlgorithm.Algorithm.Id);
+        Assert.True(csr.Verify());
+        Assert.Equal(2048, ((RsaKeyParameters)csr.GetPublicKey()).Modulus.BitLength);
+    }
+}

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -228,33 +228,14 @@ public class CertificateManager(
     {
         try
         {
-            X509KeyUsageFlags? keyUsages = null;
-            foreach (X509Extension ext in cert.Extensions)
-            {
-                if (ext is X509KeyUsageExtension keyUsage)
-                {
-                    keyUsages = keyUsage.KeyUsages;
-                    break;
-                }
-            }
             LogInformation(
                 $"Found certificate with thumbprint {cert.Thumbprint} and subject {cert.Subject} expiring on {cert.NotAfter}"
             );
-            LogInformation("Creating CSR for certificate");
-            bool makePrivateKeyExportable = false;
-            // Extract key usages from the existing certificate
-            string csr = certStoreService.CreateCSR(
-                cert.SubjectName.Name,
-                GetSubjectAlternativeNames(cert)
-                    .Where(i => i.Type == SANTypes.DNSName)
-                    .Select(i => i.Value)
-                    .ToList(),
-                CertUtils.GetKeyLength(cert),
+            string csr = CreateRenewalCSR(
+                cert,
                 values.LocalCertStore,
-                [],
                 string.Empty,
-                keyUsages,
-                makePrivateKeyExportable
+                makePrivateKeyExportable: false
             );
             LogInformation("Renewing certificate");
             EZCAClientClass ezcaClient = new(_httpClient, _logger, values.url);
@@ -334,37 +315,16 @@ public class CertificateManager(
             LogInformation(
                 $"Renewing certificate for {(string.IsNullOrWhiteSpace(values.Domain) ? cert.Subject : values.Domain)}"
             );
-            X509KeyUsageFlags? keyUsages = null;
-            foreach (X509Extension ext in cert.Extensions)
-            {
-                if (ext is X509KeyUsageExtension keyUsage)
-                {
-                    keyUsages = keyUsage.KeyUsages;
-                    break;
-                }
-            }
-
             LogInformation(
                 $"Found certificate with thumbprint {cert.Thumbprint} and subject {cert.Subject} expiring on {cert.NotAfter}"
             );
 
-            LogInformation($"Creating CSR for certificate");
-
-            bool makePrivateKeyExportable = ShouldMakePrivateKeyExportable(values.Path);
-
-            // Extract key usages from the existing certificate
-            string csr = certStoreService.CreateCSR(
-                cert.SubjectName.Name,
-                GetSubjectAlternativeNames(cert)
-                    .Where(i => i.Type == SANTypes.DNSName)
-                    .Select(i => i.Value)
-                    .ToList(),
-                values.KeyLength,
+            string csr = CreateRenewalCSR(
+                cert,
                 values.LocalCertStore,
-                [],
                 values.KeyProvider,
-                keyUsages,
-                makePrivateKeyExportable
+                ShouldMakePrivateKeyExportable(values.Path),
+                values.KeyLength
             );
             LogInformation($"Renewing certificate");
             EZCAClientClass ezcaClient = new(_httpClient, _logger, values.url);
@@ -400,6 +360,45 @@ public class CertificateManager(
         }
 
         return 0;
+    }
+
+    private string CreateRenewalCSR(
+        X509Certificate2 cert,
+        bool localStore,
+        string keyProvider,
+        bool makePrivateKeyExportable,
+        int? keyLengthOverride = null
+    )
+    {
+        X509KeyUsageFlags? keyUsages = null;
+        foreach (X509Extension ext in cert.Extensions)
+        {
+            if (ext is X509KeyUsageExtension keyUsage)
+            {
+                keyUsages = keyUsage.KeyUsages;
+                break;
+            }
+        }
+
+        int keyLength = keyLengthOverride ?? CertUtils.GetKeyLength(cert);
+        HashAlgorithmName hashAlgorithm = CertUtils.GetHashAlgorithm(cert);
+        LogInformation(
+            $"Creating CSR for certificate with a {keyLength} bit key and {hashAlgorithm.Name}"
+        );
+        return certStoreService.CreateCSR(
+            cert.SubjectName.Name,
+            GetSubjectAlternativeNames(cert)
+                .Where(i => i.Type == SANTypes.DNSName)
+                .Select(i => i.Value)
+                .ToList(),
+            keyLength,
+            localStore,
+            [],
+            keyProvider,
+            keyUsages,
+            makePrivateKeyExportable,
+            hashAlgorithm
+        );
     }
 
     private bool ShouldMakePrivateKeyExportable(string? path)
@@ -622,7 +621,7 @@ public class CertificateManager(
             );
         }
 
-        if (values.KeyLength != 2048 && values.KeyLength != 4096)
+        if (values.KeyLength.HasValue && values.KeyLength != 2048 && values.KeyLength != 4096)
         {
             throw new ArgumentException("Key length must be 2048 or 4096");
         }

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/RenewArgModel.cs
@@ -65,8 +65,13 @@ public class RenewArgModel
     [Option('i', "Issuer", Required = false, Default = "", HelpText = "Certificate Issuer Name")]
     public string issuer { get; set; } = "";
 
-    [Option('k', "KeyLength", HelpText = "Certificate Key Length", Default = 4096)]
-    public int KeyLength { get; set; } = 4096;
+    [Option(
+        'k',
+        "KeyLength",
+        Required = false,
+        HelpText = "Certificate Key Length. If not specified, the key length of the certificate being renewed is used."
+    )]
+    public int? KeyLength { get; set; }
 
     [Option(
         'p',

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/CertUtils.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/CertUtils.cs
@@ -39,6 +39,22 @@ public static class CertUtils
         throw new ArgumentException("Certificate Key not supported");
     }
 
+    public static HashAlgorithmName GetHashAlgorithm(X509Certificate2 cert)
+    {
+        ArgumentNullException.ThrowIfNull(cert);
+
+        // Anything else (SHA1, MD5, or an algorithm that does not carry the hash in its OID such
+        // as RSASSA-PSS) falls back to SHA256 so we never sign a request with a weaker hash
+        return cert.SignatureAlgorithm.Value switch
+        {
+            // sha384WithRSAEncryption, ecdsa-with-SHA384
+            "1.2.840.113549.1.1.12" or "1.2.840.10045.4.3.3" => HashAlgorithmName.SHA384,
+            // sha512WithRSAEncryption, ecdsa-with-SHA512
+            "1.2.840.113549.1.1.13" or "1.2.840.10045.4.3.4" => HashAlgorithmName.SHA512,
+            _ => HashAlgorithmName.SHA256,
+        };
+    }
+
     public static int GetPercentageOfLifetimeLeft(X509Certificate2 cert)
     {
         ArgumentNullException.ThrowIfNull(cert);

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/ICertStoreService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/ICertStoreService.cs
@@ -14,7 +14,8 @@ public interface ICertStoreService
         List<string> ekus,
         string keyProvider = "",
         X509KeyUsageFlags? keyUsageFlags = null,
-        bool makePrivateKeyExportable = false
+        bool makePrivateKeyExportable = false,
+        HashAlgorithmName? hashAlgorithm = null
     );
 
     RSA ConvertToDotnetRSA(RsaPrivateCrtKeyParameters rsaParams);

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/UnifiedCertService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/UnifiedCertService.cs
@@ -27,14 +27,15 @@ public class UnifiedCertStoreService(IStoreService storeService) : ICertStoreSer
         List<string> ekus,
         string keyProvider = "",
         X509KeyUsageFlags? keyUsage = null,
-        bool makePrivateKeyExportable = false
+        bool makePrivateKeyExportable = false,
+        HashAlgorithmName? hashAlgorithm = null
     )
     {
         AsymmetricCipherKeyPair keyPair = GenerateKeyPair(keylength);
         X509Name x509Name = new(subjectName);
         X509KeyUsage usage = ConvertDotnetKeyUsagesToBouncy(keyUsage);
         Pkcs10CertificationRequest pkcs10 = new(
-            "SHA256WITHRSA",
+            GetSignatureAlgorithm(keyPair, hashAlgorithm),
             x509Name,
             keyPair.Public,
             CreateAttributes(sans, ekus, usage),
@@ -130,6 +131,16 @@ public class UnifiedCertStoreService(IStoreService storeService) : ICertStoreSer
         }
 
         return csrPemBuilder.ToString();
+    }
+
+    private static string GetSignatureAlgorithm(
+        AsymmetricCipherKeyPair keyPair,
+        HashAlgorithmName? hashAlgorithm
+    )
+    {
+        string hash = (hashAlgorithm ?? HashAlgorithmName.SHA256).Name ?? "SHA256";
+        string keyAlgorithm = keyPair.Public is ECPublicKeyParameters ? "ECDSA" : "RSA";
+        return $"{hash}WITH{keyAlgorithm}";
     }
 
     private static AsymmetricCipherKeyPair GenerateKeyPair(int keyLength)

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/WindowsCertStoreService.cs
@@ -24,7 +24,8 @@ public class WindowsCertService(IStoreService storeService) : ICertStoreService
         List<string> ekus,
         string KeyProvider = "Microsoft Enhanced Cryptographic Provider v1.0",
         X509KeyUsageFlags? keyUsageFlags = null,
-        bool makePrivateKeyExportable = false
+        bool makePrivateKeyExportable = false,
+        HashAlgorithmName? hashAlgorithm = null
     )
     {
         CX509CertificateRequestPkcs10 certRequest = new();
@@ -50,6 +51,14 @@ public class WindowsCertService(IStoreService storeService) : ICertStoreService
         certRequest.PrivateKey.MachineContext = localStore;
         certRequest.PrivateKey.ProviderName = KeyProvider;
         certRequest.PrivateKey.Create();
+        CObjectId hashAlgorithmId = new();
+        hashAlgorithmId.InitializeFromAlgorithmName(
+            ObjectIdGroupId.XCN_CRYPT_HASH_ALG_OID_GROUP_ID,
+            ObjectIdPublicKeyFlags.XCN_CRYPT_OID_INFO_PUBKEY_ANY,
+            AlgorithmFlags.AlgorithmFlagsNone,
+            (hashAlgorithm ?? HashAlgorithmName.SHA256).Name ?? "SHA256"
+        );
+        certRequest.HashAlgorithm = hashAlgorithmId;
         CX500DistinguishedName objDN = new();
         certRequest.X509Extensions.Add((CX509Extension)CreateSans(sans));
         objDN.Encode(subjectName, X500NameFlags.XCN_CERT_NAME_STR_NONE);


### PR DESCRIPTION
## What changed

Renewal now inherits the key size and signature hash from the certificate being renewed instead of always generating a 4096 bit key and a SHA256-signed CSR.

- `CertUtils.GetHashAlgorithm(cert)` maps the certificate's signature OID to SHA384/SHA512, falling back to SHA256 for everything else. Key length reuses the existing `CertUtils.GetKeyLength(cert)`.
- `CreateCSR` gained an optional `HashAlgorithmName? hashAlgorithm` on `ICertStoreService` and both implementations. The Bouncy Castle path builds the signature algorithm from the hash *and* the key type (`SHA384WITHRSA`, `SHA256WITHECDSA`, ...) instead of the hardcoded `SHA256WITHRSA`; the Windows CertEnroll path sets `certRequest.HashAlgorithm`. All other callers (generate, DC, SCEP) are unchanged and still default to SHA256.
- `renew` and `renew-all` share one `CreateRenewalCSR` helper — the key-usage extraction, SAN filtering and `CreateCSR` call were duplicated in both paths.
- `-k/--KeyLength` on `renew` is now optional (`int?`) and only overrides when explicitly passed; validation only runs when a value is supplied.

## Why

Renewing a 2048 bit certificate produced a 4096 bit key, and renewing a SHA384/SHA512 certificate produced a SHA256-signed request — the renewal silently changed properties the original certificate was issued with.

## Notes for the reviewer

- Certificates signed with a hash weaker than SHA256 (SHA1, MD5) — and RSASSA-PSS, whose hash is not in the signature OID — renew with SHA256 rather than reproducing the weaker hash.
- `renew-all` already carried the key size over; it now carries the hash too.
- Behavior change worth a look: a legacy RSA certificate under 2048 bits now renews at its own size, and `UnifiedCertStoreService.GenerateKeyPair` branches to EC below 2048 bits. Same for ECC certificates on Linux — the renewal now generates an EC key (previously a 4096 bit RSA key), and `AddPrivateKeyToCertificate` still casts to `RsaPrivateCrtKeyParameters`, so installing it would throw. That gap already existed on the `renew-all` path; happy to address it here if you'd prefer.

## Testing

New offline unit tests in `RenewalKeyAndHashTests` cover the hash lookup (RSA + ECDSA, SHA256/384/512, SHA1 fallback), the key length lookup, and assert the generated CSR actually carries the requested key size and signature OID. 14 new tests pass alongside the existing 10 SCEP tests; both target frameworks build (`net10.0-windows` requires VS MSBuild for its COM reference) and csharpier reports no changes.

Unrelated to this change: `ScepCaCertificateParsingTests.SelectIssuingCaCertificate_ThreeTierChain_ReturnsBottomMostCa` is flaky on `main` (fails roughly 1 run in 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)