### PR TITLE
Update SCEPCertificate to support multiple SAN types

### DIFF
--- a/DotNetCertAuthSample/DotNetCertAuthSample.Test/SubjectAlternativeNameParserTests.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample.Test/SubjectAlternativeNameParserTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using DotNetCertAuthSample.Services;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Xunit;
+
+namespace DotNetCertAuthSample.Test;
+
+/// <summary>
+/// Offline unit tests for the --SubjectAltNames parsing used by the SCEPCertificate command.
+/// Names without a type prefix stay DNS names (the original behavior), while a prefix such as
+/// UPN=, IP=, RFC822=, URI= or SID= requests that specific Subject Alternative Name type.
+/// </summary>
+public class SubjectAlternativeNameParserTests
+{
+    [Theory]
+    [InlineData("server1.contoso.com")]
+    [InlineData("DNS=server1.contoso.com")]
+    [InlineData("dns=server1.contoso.com")]
+    [InlineData(" DNS = server1.contoso.com ")]
+    public void Parse_Returns_DnsName(string input)
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse(input));
+
+        Assert.Equal(GeneralName.DnsName, name.TagNo);
+        Assert.Equal("server1.contoso.com", name.Name.ToString());
+    }
+
+    [Fact]
+    public void Parse_Without_Prefix_Keeps_All_Names_As_Dns()
+    {
+        GeneralName[] names = SubjectAlternativeNameParser.Parse(
+            "one.contoso.com,two.contoso.com,three.contoso.com"
+        );
+
+        Assert.Equal(
+            new[] { GeneralName.DnsName, GeneralName.DnsName, GeneralName.DnsName },
+            names.Select(name => name.TagNo).ToArray()
+        );
+        Assert.Equal(
+            new[] { "one.contoso.com", "two.contoso.com", "three.contoso.com" },
+            names.Select(name => name.Name.ToString()).ToArray()
+        );
+    }
+
+    [Fact]
+    public void Parse_Upn_Creates_OtherName_With_Upn_Oid()
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse("UPN=aaron@keytos.io"));
+
+        Assert.Equal(GeneralName.OtherName, name.TagNo);
+        Asn1Sequence otherName = Asn1Sequence.GetInstance(name.Name);
+        Assert.Equal(
+            SubjectAlternativeNameParser.UpnOid,
+            DerObjectIdentifier.GetInstance(otherName[0]).Id
+        );
+        DerUtf8String upn = DerUtf8String.GetInstance(
+            Asn1TaggedObject.GetInstance(otherName[1]).GetBaseObject()
+        );
+        Assert.Equal("aaron@keytos.io", upn.GetString());
+    }
+
+    [Theory]
+    [InlineData("IP=10.0.0.5", "10.0.0.5")]
+    [InlineData("IPAddress=10.0.0.5", "10.0.0.5")]
+    [InlineData("IP=2001:db8::1", "2001:db8::1")]
+    public void Parse_IpAddress_Encodes_Address_Octets(string input, string expected)
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse(input));
+
+        Assert.Equal(GeneralName.IPAddress, name.TagNo);
+        byte[] octets = ((DerOctetString)name.Name).GetOctets();
+        Assert.Equal(IPAddress.Parse(expected).GetAddressBytes(), octets);
+    }
+
+    [Theory]
+    [InlineData("IP=not-an-ip")]
+    [InlineData("IP=10.0.0.256")]
+    public void Parse_Invalid_IpAddress_Throws(string input)
+    {
+        Assert.Throws<ArgumentException>(() => SubjectAlternativeNameParser.Parse(input));
+    }
+
+    [Theory]
+    [InlineData("RFC822=aaron@keytos.io")]
+    [InlineData("Rfc822Name=aaron@keytos.io")]
+    [InlineData("EMAIL=aaron@keytos.io")]
+    public void Parse_Rfc822_Returns_Rfc822Name(string input)
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse(input));
+
+        Assert.Equal(GeneralName.Rfc822Name, name.TagNo);
+        Assert.Equal("aaron@keytos.io", name.Name.ToString());
+    }
+
+    [Theory]
+    [InlineData("URI=https://contoso.com/app")]
+    [InlineData("URL=https://contoso.com/app")]
+    public void Parse_Uri_Returns_UniformResourceIdentifier(string input)
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse(input));
+
+        Assert.Equal(GeneralName.UniformResourceIdentifier, name.TagNo);
+        Assert.Equal("https://contoso.com/app", name.Name.ToString());
+    }
+
+    [Theory]
+    [InlineData("SID=S-1-5-21-1004336348-1177238915-682003330-512")]
+    [InlineData(
+        "SID=tag:microsoft.com\\,2022-09-14:sid:S-1-5-21-1004336348-1177238915-682003330-512"
+    )]
+    [InlineData(
+        "URI=tag:microsoft.com\\,2022-09-14:sid:S-1-5-21-1004336348-1177238915-682003330-512"
+    )]
+    public void Parse_Sid_Returns_Microsoft_Sid_Uri(string input)
+    {
+        GeneralName name = Assert.Single(SubjectAlternativeNameParser.Parse(input));
+
+        Assert.Equal(GeneralName.UniformResourceIdentifier, name.TagNo);
+        Assert.Equal(
+            "tag:microsoft.com,2022-09-14:sid:S-1-5-21-1004336348-1177238915-682003330-512",
+            name.Name.ToString()
+        );
+    }
+
+    [Fact]
+    public void Parse_Mixed_Types_Keeps_Order_And_Types()
+    {
+        GeneralName[] names = SubjectAlternativeNameParser.Parse(
+            "server1.contoso.com, UPN=aaron@keytos.io ,IP=10.0.0.5,EMAIL=aaron@keytos.io,URI=https://contoso.com"
+        );
+
+        Assert.Equal(
+            new[]
+            {
+                GeneralName.DnsName,
+                GeneralName.OtherName,
+                GeneralName.IPAddress,
+                GeneralName.Rfc822Name,
+                GeneralName.UniformResourceIdentifier,
+            },
+            names.Select(name => name.TagNo).ToArray()
+        );
+    }
+
+    [Fact]
+    public void Parse_Unknown_Type_Throws()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            SubjectAlternativeNameParser.Parse("SPN=host/server1.contoso.com")
+        );
+
+        Assert.Contains("SPN", exception.Message);
+    }
+
+    [Fact]
+    public void Parse_Value_With_Equals_Sign_Is_Not_Treated_As_A_Type()
+    {
+        GeneralName name = Assert.Single(
+            SubjectAlternativeNameParser.Parse("URI=https://contoso.com/app?key=value")
+        );
+
+        Assert.Equal(GeneralName.UniformResourceIdentifier, name.TagNo);
+        Assert.Equal("https://contoso.com/app?key=value", name.Name.ToString());
+    }
+
+    [Fact]
+    public void Parse_Missing_Value_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => SubjectAlternativeNameParser.Parse("UPN="));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",")]
+    public void Parse_Empty_Input_Throws(string input)
+    {
+        Assert.Throws<ArgumentException>(() => SubjectAlternativeNameParser.Parse(input));
+    }
+
+    [Fact]
+    public void Parsed_Names_Produce_An_Extension_DotNet_Can_Read()
+    {
+        GeneralNames generalNames = new(
+            SubjectAlternativeNameParser.Parse(
+                "server1.contoso.com,UPN=aaron@keytos.io,IP=10.0.0.5,EMAIL=aaron@keytos.io"
+            )
+        );
+
+        X509SubjectAlternativeNameExtension extension = new(
+            generalNames.GetDerEncoded(),
+            critical: false
+        );
+
+        // The UPN is an otherName, so it must not come back as a DNS name.
+        string dnsName = Assert.Single(extension.EnumerateDnsNames());
+        Assert.Equal("server1.contoso.com", dnsName);
+        IPAddress ipAddress = Assert.Single(extension.EnumerateIPAddresses());
+        Assert.Equal(IPAddress.Parse("10.0.0.5"), ipAddress);
+    }
+}

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Managers/CertificateManager.cs
@@ -1184,10 +1184,7 @@ public class CertificateManager(
         if (!string.IsNullOrWhiteSpace(values.SubjectAltNames))
         {
             GeneralNames subjectAlternateNames = new(
-                values
-                    .SubjectAltNames.Split(',')
-                    .Select(dnsName => new GeneralName(GeneralName.DnsName, dnsName))
-                    .ToArray()
+                SubjectAlternativeNameParser.Parse(values.SubjectAltNames)
             );
             extensions.AddExtension(
                 X509Extensions.SubjectAlternativeName,

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
@@ -59,7 +59,10 @@ public class SCEPArgModel
     [Option(
         "SubjectAltNames",
         Required = false,
-        HelpText = "Subject Alternate Names for this certificate for example (comma separate multiple): server1.constoso.com,server2.contoso.com"
+        HelpText = "Subject Alternate Names for this certificate (comma separate multiple): server1.constoso.com,server2.contoso.com. "
+            + "Each name defaults to a DNS name, prefix it to request another type: DNS=, UPN=, IP=, RFC822= (or EMAIL=), URI= (or URL=), SID=. "
+            + "For example: server1.contoso.com,UPN=user@contoso.com,IP=10.0.0.5,SID=S-1-5-21-1-2-3-1000. "
+            + "Escape a comma inside a value with a backslash."
     )]
     public string? SubjectAltNames { get; set; }
 

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Models/SCEPArgModel.cs
@@ -59,7 +59,7 @@ public class SCEPArgModel
     [Option(
         "SubjectAltNames",
         Required = false,
-        HelpText = "Subject Alternate Names for this certificate (comma separate multiple): server1.constoso.com,server2.contoso.com. "
+        HelpText = "Subject Alternative Names for this certificate (comma separated multiple): server1.contoso.com,server2.contoso.com. "
             + "Each name defaults to a DNS name, prefix it to request another type: DNS=, UPN=, IP=, RFC822= (or EMAIL=), URI= (or URL=), SID=. "
             + "For example: server1.contoso.com,UPN=user@contoso.com,IP=10.0.0.5,SID=S-1-5-21-1-2-3-1000. "
             + "Escape a comma inside a value with a backslash."

--- a/DotNetCertAuthSample/DotNetCertAuthSample/Services/SubjectAlternativeNameParser.cs
+++ b/DotNetCertAuthSample/DotNetCertAuthSample/Services/SubjectAlternativeNameParser.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+
+namespace DotNetCertAuthSample.Services;
+
+/// <summary>
+/// Parses the comma separated --SubjectAltNames value into ASN.1 Subject Alternative Names.
+/// Each entry may declare its type with a prefix (DNS=, UPN=, IP=, RFC822=, URI=, SID=).
+/// Entries without a prefix are treated as DNS names so existing commands keep working.
+/// A comma inside a value can be escaped with a backslash (for example URI=tag:example.com\,2022:foo).
+/// </summary>
+public static class SubjectAlternativeNameParser
+{
+    /// <summary>OID for the Microsoft User Principal Name otherName SAN.</summary>
+    public const string UpnOid = "1.3.6.1.4.1.311.20.2.3";
+
+    /// <summary>
+    /// Prefix of the URI SAN Microsoft uses to carry an account SID (see KB5014754).
+    /// </summary>
+    public const string SidUriPrefix = "tag:microsoft.com,2022-09-14:sid:";
+
+    public static GeneralName[] Parse(string subjectAltNames)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectAltNames);
+        List<string> entries = SplitEntries(subjectAltNames);
+        if (entries.Count == 0)
+        {
+            throw new ArgumentException(
+                $"'{subjectAltNames}' does not contain any Subject Alternative Names."
+            );
+        }
+
+        return entries.Select(ParseEntry).ToArray();
+    }
+
+    private static GeneralName ParseEntry(string entry)
+    {
+        (string? type, string value) = SplitTypeAndValue(entry);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException(
+                $"Subject Alternative Name '{entry}' does not have a value."
+            );
+        }
+
+        // No prefix means the caller is using the original syntax, where every value is a DNS name.
+        if (type == null)
+        {
+            return new GeneralName(GeneralName.DnsName, value);
+        }
+
+        switch (type.ToUpperInvariant())
+        {
+            case "DNS":
+            case "DNSNAME":
+                return new GeneralName(GeneralName.DnsName, value);
+            case "UPN":
+                return CreateUpnName(value);
+            case "IP":
+            case "IPADDRESS":
+                return CreateIPAddressName(value);
+            case "RFC822":
+            case "RFC822NAME":
+            case "EMAIL":
+                return new GeneralName(GeneralName.Rfc822Name, value);
+            case "URI":
+            case "URL":
+                return new GeneralName(GeneralName.UniformResourceIdentifier, value);
+            case "SID":
+                return new GeneralName(
+                    GeneralName.UniformResourceIdentifier,
+                    value.StartsWith(SidUriPrefix, StringComparison.OrdinalIgnoreCase)
+                        ? value
+                        : SidUriPrefix + value
+                );
+            default:
+                throw new ArgumentException(
+                    $"'{type}' is not a supported Subject Alternative Name type. "
+                        + "Supported types are DNS, UPN, IP, RFC822 (or EMAIL), URI (or URL) and SID."
+                );
+        }
+    }
+
+    private static GeneralName CreateUpnName(string value)
+    {
+        // otherName ::= SEQUENCE { type-id OBJECT IDENTIFIER, value [0] EXPLICIT UTF8String }
+        DerSequence otherName = new(
+            new DerObjectIdentifier(UpnOid),
+            new DerTaggedObject(true, 0, new DerUtf8String(value))
+        );
+        return new GeneralName(GeneralName.OtherName, otherName);
+    }
+
+    private static GeneralName CreateIPAddressName(string value)
+    {
+        if (
+            !IPAddress.TryParse(value, out IPAddress? ipAddress)
+            || ipAddress.AddressFamily
+                is not (AddressFamily.InterNetwork or AddressFamily.InterNetworkV6)
+        )
+        {
+            throw new ArgumentException($"'{value}' is not a valid IP address.");
+        }
+
+        return new GeneralName(
+            GeneralName.IPAddress,
+            new DerOctetString(ipAddress.GetAddressBytes())
+        );
+    }
+
+    /// <summary>
+    /// Returns the type prefix of an entry, or null when the entry has no prefix. Only a bare
+    /// alphanumeric token before the first '=' counts as a prefix, so values such as
+    /// https://contoso.com/path?key=value are not mistaken for a type declaration.
+    /// </summary>
+    private static (string? Type, string Value) SplitTypeAndValue(string entry)
+    {
+        int separator = entry.IndexOf('=');
+        if (separator <= 0)
+        {
+            return (null, entry.Trim());
+        }
+
+        string prefix = entry[..separator].Trim();
+        if (prefix.Length == 0 || !prefix.All(char.IsAsciiLetterOrDigit))
+        {
+            return (null, entry.Trim());
+        }
+
+        return (prefix, entry[(separator + 1)..].Trim());
+    }
+
+    /// <summary>
+    /// Splits on commas, honoring backslash escaped commas so values that contain a comma
+    /// (such as the Microsoft SID URI) can be passed as a single entry.
+    /// </summary>
+    private static List<string> SplitEntries(string subjectAltNames)
+    {
+        List<string> entries = [];
+        StringBuilder current = new();
+        for (int i = 0; i < subjectAltNames.Length; i++)
+        {
+            char character = subjectAltNames[i];
+            if (
+                character == '\\'
+                && i + 1 < subjectAltNames.Length
+                && subjectAltNames[i + 1] == ','
+            )
+            {
+                current.Append(',');
+                i++;
+                continue;
+            }
+
+            if (character == ',')
+            {
+                AddEntry(entries, current);
+                continue;
+            }
+
+            current.Append(character);
+        }
+
+        AddEntry(entries, current);
+        return entries;
+    }
+
+    private static void AddEntry(List<string> entries, StringBuilder current)
+    {
+        string entry = current.ToString().Trim();
+        current.Clear();
+        if (entry.Length > 0)
+        {
+            entries.Add(entry);
+        }
+    }
+}


### PR DESCRIPTION
Allows SCEP certificates to specify any SAN type such as SID, IP, DNS, EMAIL

Maintains backwards compatibility by using DNS when no prefix is specified.

Adds tests to ensure SAN parsing works as expected